### PR TITLE
Add Options menu for vim editor in the Project.jsx.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.4",
+        "@monaco-editor/react": "^4.7.0",
         "@replit/codemirror-vim": "^6.3.0",
         "@uiw/codemirror-theme-vscode": "^4.24.0",
         "@uiw/react-codemirror": "^4.23.14",
@@ -18,6 +19,8 @@
         "framer-motion": "^10.16.4",
         "highlight.js": "^11.11.1",
         "markdown-to-jsx": "^7.7.10",
+        "monaco-editor": "^0.52.2",
+        "monaco-vim": "^0.4.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.3",
@@ -1198,6 +1201,29 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4100,6 +4126,21 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
+    "node_modules/monaco-vim": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/monaco-vim/-/monaco-vim-0.4.2.tgz",
+      "integrity": "sha512-rdbQC3O2rmpwX2Orzig/6gZjZfH7q7TIeB+uEl49sa+QyNm3jCKJOw5mwxBdFzTqbrPD+URfg6A2lEkuL5kymw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5265,6 +5306,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.4",
         "@replit/codemirror-vim": "^6.3.0",
+        "@uiw/codemirror-theme-vscode": "^4.24.0",
         "@uiw/react-codemirror": "^4.23.14",
         "@webcontainer/api": "^1.0.0",
         "animate.css": "^4.1.1",
@@ -1348,6 +1349,37 @@
         "@codemirror/language": ">=6.0.0",
         "@codemirror/lint": ">=6.0.0",
         "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-vscode": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-vscode/-/codemirror-theme-vscode-4.24.0.tgz",
+      "integrity": "sha512-rRtmxLC47ztWzG192/9BQO/qf3lWnsOsB1SgF8NKrvb2qLNOyJL6pV2d90ddfjsU8Yq8UoXJ99pz+fn8kcFe9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.24.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-themes": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.24.0.tgz",
+      "integrity": "sha512-Bsq/j7ASqNcdboacM9KVdxnBlkiMZEk4rpq1FLTnYNULqGUVuP1BoUNoMEZ/CaxQAlUez6m5MskMxPKj3YEa3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/language": ">=6.0.0",
         "@codemirror/state": ">=6.0.0",
         "@codemirror/view": ">=6.0.0"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "monaco-vim": "^0.4.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-modal": "^3.16.3",
         "react-router-dom": "^7.1.3",
         "remixicon": "^4.6.0",
         "socket.io-client": "^4.8.1"
@@ -2788,6 +2789,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4137,6 +4144,21 @@
         "monaco-editor": "*"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.22.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.22.0.tgz",
+      "integrity": "sha512-ooH7+/BPw9gOsL9VtPhEJHE2m4ltnhMlcGMhEqA0YGNhKof7jdaszvsyThXI6LVIKshJUZ9/CP6HNqQhJfV7kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4212,7 +4234,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4713,7 +4734,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4787,8 +4807,29 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-modal": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -5920,6 +5961,15 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "monaco-vim": "^0.4.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-modal": "^3.16.3",
     "react-router-dom": "^7.1.3",
     "remixicon": "^4.6.0",
     "socket.io-client": "^4.8.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.4",
+    "@monaco-editor/react": "^4.7.0",
     "@replit/codemirror-vim": "^6.3.0",
     "@uiw/codemirror-theme-vscode": "^4.24.0",
     "@uiw/react-codemirror": "^4.23.14",
@@ -20,6 +21,8 @@
     "framer-motion": "^10.16.4",
     "highlight.js": "^11.11.1",
     "markdown-to-jsx": "^7.7.10",
+    "monaco-editor": "^0.52.2",
+    "monaco-vim": "^0.4.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.4",
     "@replit/codemirror-vim": "^6.3.0",
+    "@uiw/codemirror-theme-vscode": "^4.24.0",
     "@uiw/react-codemirror": "^4.23.14",
     "@webcontainer/api": "^1.0.0",
     "animate.css": "^4.1.1",

--- a/frontend/src/components/VimCodeEditor.jsx
+++ b/frontend/src/components/VimCodeEditor.jsx
@@ -1,0 +1,280 @@
+import { useRef, useState, useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import CodeMirror from '@uiw/react-codemirror';
+import { javascript } from '@codemirror/lang-javascript';
+import { vim } from '@replit/codemirror-vim';
+import { vscodeDark } from '@uiw/codemirror-theme-vscode';
+import { EditorView, keymap, highlightActiveLine, highlightActiveLineGutter, lineNumbers, rectangularSelection, drawSelection, highlightSpecialChars } from '@codemirror/view';
+import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
+import { searchKeymap, highlightSelectionMatches, search } from '@codemirror/search';
+import { foldGutter, foldKeymap, bracketMatching } from '@codemirror/language';
+import { autocompletion, completionKeymap } from '@codemirror/autocomplete';
+import { closeBrackets } from '@codemirror/autocomplete';
+
+// VS Code-like Command Palette
+const COMMANDS = [
+  { label: 'Cut', action: () => document.execCommand('cut') },
+  { label: 'Copy', action: () => document.execCommand('copy') },
+  { label: 'Paste', action: () => document.execCommand('paste') },
+  { label: 'Undo', action: () => document.execCommand('undo') },
+  { label: 'Redo', action: () => document.execCommand('redo') },
+  { label: 'Select All', action: () => document.execCommand('selectAll') },
+  { label: 'Find', action: (view) => view && view.dispatch({ effects: search.openSearchPanel.of(true) }) },
+  { label: 'Toggle Line Numbers', action: null },
+  { label: 'Toggle Vim Mode', action: null },
+];
+
+const VimCodeEditor = ({
+  value,
+  onChange,
+  isDarkMode,
+  fontSize = '1rem',
+  language = 'javascript',
+  ...rest
+}) => {
+  const editorRef = useRef(null);
+  const [showPalette, setShowPalette] = useState(false);
+  const [paletteQuery, setPaletteQuery] = useState('');
+  const [status, setStatus] = useState({
+    mode: 'NORMAL',
+    line: 1,
+    col: 1,
+    language: language,
+  });
+
+  // Update status bar on cursor move
+  const handleUpdate = useCallback((viewUpdate) => {
+    if (viewUpdate.state && viewUpdate.state.selection) {
+      const { main } = viewUpdate.state.selection;
+      // Guard: CodeMirror lines are 1-based, main.head can be 0
+      let line = 1;
+      let col = 1;
+      if (main.head >= 0 && main.head < viewUpdate.state.doc.length) {
+        const lineObj = viewUpdate.state.doc.lineAt(main.head);
+        line = lineObj.number;
+        col = main.head - lineObj.from + 1;
+      }
+      setStatus((s) => {
+        if (s.line !== line || s.col !== col) {
+          return { ...s, line, col };
+        }
+        return s;
+      });
+    }
+  }, []);
+
+  // Command palette logic
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'p') {
+        e.preventDefault();
+        setShowPalette((v) => !v);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  // Custom context menu for VS Code-like feel
+  const handleContextMenu = useCallback((e) => {
+    e.preventDefault();
+    const menu = document.createElement('div');
+    menu.style.position = 'fixed';
+    menu.style.left = `${e.clientX}px`;
+    menu.style.top = `${e.clientY}px`;
+    menu.style.background = isDarkMode ? '#23272e' : '#fff';
+    menu.style.color = isDarkMode ? '#fff' : '#222';
+    menu.style.border = '1px solid #444';
+    menu.style.borderRadius = '6px';
+    menu.style.boxShadow = '0 2px 12px rgba(0,0,0,0.15)';
+    menu.style.zIndex = 9999;
+    menu.style.fontSize = '14px';
+    menu.style.minWidth = '180px';
+    menu.style.padding = '4px 0';
+    const actions = [
+      { label: 'Cut', action: () => document.execCommand('cut') },
+      { label: 'Copy', action: () => document.execCommand('copy') },
+      { label: 'Paste', action: () => document.execCommand('paste') },
+      { label: 'Undo', action: () => document.execCommand('undo') },
+      { label: 'Redo', action: () => document.execCommand('redo') },
+      { label: 'Select All', action: () => document.execCommand('selectAll') },
+      { label: 'Find', action: () => editorRef.current && editorRef.current.view && editorRef.current.view.dispatch({ effects: search.openSearchPanel.of(true) }) },
+    ];
+    actions.forEach(({ label, action }) => {
+      const item = document.createElement('div');
+      item.textContent = label;
+      item.style.padding = '6px 18px';
+      item.style.cursor = 'pointer';
+      item.onmouseenter = () => (item.style.background = isDarkMode ? '#333' : '#f0f0f0');
+      item.onmouseleave = () => (item.style.background = '');
+      item.onclick = () => {
+        action();
+        document.body.removeChild(menu);
+      };
+      menu.appendChild(item);
+    });
+    document.body.appendChild(menu);
+    const removeMenu = () => {
+      if (menu.parentNode) menu.parentNode.removeChild(menu);
+      window.removeEventListener('click', removeMenu);
+    };
+    setTimeout(() => window.addEventListener('click', removeMenu), 0);
+  }, [isDarkMode]);
+
+  // Status bar mode update (Vim)
+  useEffect(() => {
+    if (!editorRef.current || !editorRef.current.view) return;
+    const cm = editorRef.current.view;
+    // Listen for Vim mode changes
+    const handler = (event) => {
+      if (event && event.mode) {
+        setStatus((s) => ({ ...s, mode: event.mode.toUpperCase() }));
+      }
+    };
+    window.CodeMirror && window.CodeMirror.on && window.CodeMirror.on(cm, 'vim-mode-change', handler);
+    return () => {
+      window.CodeMirror && window.CodeMirror.off && window.CodeMirror.off(cm, 'vim-mode-change', handler);
+    };
+  }, []);
+
+  // Command palette filtered commands
+  const filteredCommands = COMMANDS.filter(cmd =>
+    cmd.label.toLowerCase().includes(paletteQuery.toLowerCase())
+  );
+
+  // Editor extensions
+  const extensions = [
+    lineNumbers(),
+    highlightActiveLineGutter(),
+    highlightSpecialChars(),
+    drawSelection(),
+    EditorView.lineWrapping,
+    highlightActiveLine(),
+    rectangularSelection(),
+    history(),
+    keymap.of([
+      ...defaultKeymap,
+      ...historyKeymap,
+      ...searchKeymap,
+      ...foldKeymap,
+      ...completionKeymap,
+      indentWithTab,
+    ]),
+    foldGutter(),
+    highlightSelectionMatches(),
+    autocompletion(),
+    bracketMatching(),
+    closeBrackets(),
+    vim(),
+    javascript(),
+    EditorView.updateListener.of(handleUpdate),
+  ];
+
+  return (
+    <div onContextMenu={handleContextMenu} style={{ height: '100%', width: '100%', position: 'relative' }}>
+      <CodeMirror
+        ref={editorRef}
+        value={value}
+        height="100%"
+        theme={vscodeDark}
+        extensions={extensions}
+        onChange={onChange}
+        style={{
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          fontSize,
+          background: isDarkMode ? '#1e1e1e' : '#fff',
+          color: isDarkMode ? '#d4d4d4' : '#222',
+          minHeight: 0,
+        }}
+        {...rest}
+      />
+      {/* Status Bar */}
+      <div style={{
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        height: '28px',
+        background: isDarkMode ? '#23272e' : '#f3f3f3',
+        color: isDarkMode ? '#fff' : '#222',
+        fontSize: '13px',
+        display: 'flex',
+        alignItems: 'center',
+        padding: '0 12px',
+        borderTop: isDarkMode ? '1px solid #333' : '1px solid #ddd',
+        zIndex: 2,
+        userSelect: 'none',
+      }}>
+        <span style={{ marginRight: 16 }}><b>{status.mode}</b></span>
+        <span style={{ marginRight: 16 }}>Ln {status.line}, Col {status.col}</span>
+        <span style={{ marginRight: 16 }}>{status.language}</span>
+        <span style={{ marginLeft: 'auto', opacity: 0.7 }}>Vim Mode • Ctrl+Shift+P</span>
+      </div>
+      {/* Command Palette */}
+      {showPalette && (
+        <div style={{
+          position: 'absolute',
+          top: '20%',
+          left: '50%',
+          transform: 'translate(-50%, 0)',
+          background: isDarkMode ? '#23272e' : '#fff',
+          color: isDarkMode ? '#fff' : '#222',
+          border: '1px solid #444',
+          borderRadius: '8px',
+          boxShadow: '0 4px 32px rgba(0,0,0,0.25)',
+          zIndex: 10000,
+          minWidth: 340,
+          maxWidth: 480,
+        }}>
+          <input
+            autoFocus
+            value={paletteQuery}
+            onChange={e => setPaletteQuery(e.target.value)}
+            placeholder="Type a command..."
+            style={{
+              width: '100%',
+              padding: '12px 16px',
+              border: 'none',
+              outline: 'none',
+              background: 'inherit',
+              color: 'inherit',
+              fontSize: 16,
+              borderTopLeftRadius: 8,
+              borderTopRightRadius: 8,
+            }}
+            onKeyDown={e => {
+              if (e.key === 'Escape') setShowPalette(false);
+            }}
+          />
+          <div style={{ maxHeight: 260, overflowY: 'auto' }}>
+            {filteredCommands.length === 0 && (
+              <div style={{ padding: 16, opacity: 0.6 }}>No commands found</div>
+            )}
+            {filteredCommands.map((cmd, i) => (
+              <div
+                key={cmd.label}
+                style={{ padding: '10px 18px', cursor: 'pointer', borderBottom: '1px solid #333', background: i === 0 ? (isDarkMode ? '#333' : '#f0f0f0') : 'inherit' }}
+                onClick={() => {
+                  setShowPalette(false);
+                  if (cmd.action) { cmd.action(editorRef.current?.view); }
+                }}
+              >
+                {cmd.label}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+VimCodeEditor.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  isDarkMode: PropTypes.bool,
+  fontSize: PropTypes.string,
+  language: PropTypes.string,
+};
+
+export default VimCodeEditor;

--- a/frontend/src/components/VimCodeEditor.jsx
+++ b/frontend/src/components/VimCodeEditor.jsx
@@ -1,195 +1,251 @@
-import { useRef, useState, useCallback, useEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import CodeMirror from '@uiw/react-codemirror';
-import { javascript } from '@codemirror/lang-javascript';
-import { vim } from '@replit/codemirror-vim';
-import { vscodeDark } from '@uiw/codemirror-theme-vscode';
-import { EditorView, keymap, highlightActiveLine, highlightActiveLineGutter, lineNumbers, rectangularSelection, drawSelection, highlightSpecialChars } from '@codemirror/view';
-import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
-import { searchKeymap, highlightSelectionMatches, search } from '@codemirror/search';
-import { foldGutter, foldKeymap, bracketMatching } from '@codemirror/language';
-import { autocompletion, completionKeymap } from '@codemirror/autocomplete';
-import { closeBrackets } from '@codemirror/autocomplete';
+import MonacoEditor from '@monaco-editor/react';
+import { initVimMode, disposeVimMode } from 'monaco-vim';
 
-// VS Code-like Command Palette
-const COMMANDS = [
-  { label: 'Cut', action: () => document.execCommand('cut') },
-  { label: 'Copy', action: () => document.execCommand('copy') },
-  { label: 'Paste', action: () => document.execCommand('paste') },
-  { label: 'Undo', action: () => document.execCommand('undo') },
-  { label: 'Redo', action: () => document.execCommand('redo') },
-  { label: 'Select All', action: () => document.execCommand('selectAll') },
-  { label: 'Find', action: (view) => view && view.dispatch({ effects: search.openSearchPanel.of(true) }) },
-  { label: 'Toggle Line Numbers', action: null },
-  { label: 'Toggle Vim Mode', action: null },
+const SUPPORTED_LANGUAGES = [
+  'javascript', 'typescript', 'python', 'java', 'c', 'cpp', 'go', 'ruby', 'php', 'json', 'markdown', 'html', 'css', 'scss', 'less', 'shell', 'powershell', 'sql', 'yaml', 'xml', 'plaintext'
 ];
+
+// Additional themes
+const THEMES = [
+  { label: 'VS Dark', value: 'vs-dark' },
+  { label: 'VS Light', value: 'vs-light' },
+  { label: 'HC Black', value: 'hc-black' },
+  { label: 'HC Light', value: 'hc-light' },
+];
+
+const DEFAULT_OPTIONS = {
+  fontSize: 16,
+  minimap: { enabled: true },
+  contextmenu: true,
+  lineNumbers: 'on',
+  scrollBeyondLastLine: false,
+  smoothScrolling: true,
+  wordWrap: 'on',
+  cursorBlinking: 'blink',
+  renderLineHighlight: 'all',
+  tabSize: 2,
+  formatOnType: true,
+  formatOnPaste: true,
+  suggestOnTriggerCharacters: true,
+  quickSuggestions: true,
+  codeLens: true,
+  folding: true,
+  links: true,
+  renderWhitespace: 'all',
+  autoClosingBrackets: 'always',
+  autoClosingQuotes: 'always',
+  matchBrackets: 'always',
+  find: { seedSearchStringFromSelection: true },
+  bracketPairColorization: { enabled: true },
+  guides: { indentation: true },
+  inlayHints: { enabled: true },
+  hover: { enabled: true },
+};
 
 const VimCodeEditor = ({
   value,
   onChange,
   isDarkMode,
-  fontSize = '1rem',
+  fontSize = '16px',
   language = 'javascript',
   ...rest
 }) => {
   const editorRef = useRef(null);
-  const [showPalette, setShowPalette] = useState(false);
-  const [paletteQuery, setPaletteQuery] = useState('');
+  const vimModeRef = useRef(null);
   const [status, setStatus] = useState({
-    mode: 'NORMAL',
     line: 1,
     col: 1,
     language: language,
+    vim: false,
+    vimStatus: '',
   });
+  const [vimMode, setVimMode] = useState(false);
+  const [theme, setTheme] = useState(isDarkMode ? 'vs-dark' : 'vs-light');
+  const [editorOptions, setEditorOptions] = useState(DEFAULT_OPTIONS);
+  const [showSnippetMenu, setShowSnippetMenu] = useState(false);
+  const [showVimRemapMenu, setShowVimRemapMenu] = useState(false);
+  const [vimRemaps, setVimRemaps] = useState([]);
+  const [diagnostics, setDiagnostics] = useState([]);
+  const [fileName, setFileName] = useState('untitled.txt');
 
   // Update status bar on cursor move
-  const handleUpdate = useCallback((viewUpdate) => {
-    if (viewUpdate.state && viewUpdate.state.selection) {
-      const { main } = viewUpdate.state.selection;
-      // Guard: CodeMirror lines are 1-based, main.head can be 0
-      let line = 1;
-      let col = 1;
-      if (main.head >= 0 && main.head < viewUpdate.state.doc.length) {
-        const lineObj = viewUpdate.state.doc.lineAt(main.head);
-        line = lineObj.number;
-        col = main.head - lineObj.from + 1;
-      }
-      setStatus((s) => {
-        if (s.line !== line || s.col !== col) {
-          return { ...s, line, col };
-        }
-        return s;
+  function handleEditorChange(value, event) {
+    if (onChange) onChange(value, event);
+  }
+
+  function handleEditorDidMount(editor) {
+    editorRef.current = editor;
+    editor.onDidChangeCursorPosition(() => {
+      const position = editor.getPosition();
+      setStatus((s) => ({ ...s, line: position.lineNumber, col: position.column }));
+    });
+    // Enable Vim mode if toggled
+    if (vimMode) {
+      if (vimModeRef.current) vimModeRef.current.dispose();
+      vimModeRef.current = initVimMode(editor, document.getElementById('vim-status-bar'));
+      vimModeRef.current.onDidChangeStatus((vimStatus) => {
+        setStatus((s) => ({ ...s, vimStatus }));
       });
     }
-  }, []);
+  }
 
-  // Command palette logic
+  // Toggle Vim mode and language menu
   useEffect(() => {
-    const handleKeyDown = (e) => {
+    function handleKeyDown(e) {
+      // Command palette
       if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'p') {
-        e.preventDefault();
-        setShowPalette((v) => !v);
+        if (editorRef.current) {
+          editorRef.current.trigger('keyboard', 'editor.action.quickCommand', null);
+        }
       }
-    };
+      // Toggle Vim mode with Ctrl+Alt+V
+      if ((e.ctrlKey || e.metaKey) && e.altKey && e.key.toLowerCase() === 'v') {
+        setVimMode((v) => !v);
+      }
+    }
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  // Custom context menu for VS Code-like feel
-  const handleContextMenu = useCallback((e) => {
-    e.preventDefault();
-    const menu = document.createElement('div');
-    menu.style.position = 'fixed';
-    menu.style.left = `${e.clientX}px`;
-    menu.style.top = `${e.clientY}px`;
-    menu.style.background = isDarkMode ? '#23272e' : '#fff';
-    menu.style.color = isDarkMode ? '#fff' : '#222';
-    menu.style.border = '1px solid #444';
-    menu.style.borderRadius = '6px';
-    menu.style.boxShadow = '0 2px 12px rgba(0,0,0,0.15)';
-    menu.style.zIndex = 9999;
-    menu.style.fontSize = '14px';
-    menu.style.minWidth = '180px';
-    menu.style.padding = '4px 0';
-    const actions = [
-      { label: 'Cut', action: () => document.execCommand('cut') },
-      { label: 'Copy', action: () => document.execCommand('copy') },
-      { label: 'Paste', action: () => document.execCommand('paste') },
-      { label: 'Undo', action: () => document.execCommand('undo') },
-      { label: 'Redo', action: () => document.execCommand('redo') },
-      { label: 'Select All', action: () => document.execCommand('selectAll') },
-      { label: 'Find', action: () => editorRef.current && editorRef.current.view && editorRef.current.view.dispatch({ effects: search.openSearchPanel.of(true) }) },
-    ];
-    actions.forEach(({ label, action }) => {
-      const item = document.createElement('div');
-      item.textContent = label;
-      item.style.padding = '6px 18px';
-      item.style.cursor = 'pointer';
-      item.onmouseenter = () => (item.style.background = isDarkMode ? '#333' : '#f0f0f0');
-      item.onmouseleave = () => (item.style.background = '');
-      item.onclick = () => {
-        action();
-        document.body.removeChild(menu);
-      };
-      menu.appendChild(item);
-    });
-    document.body.appendChild(menu);
-    const removeMenu = () => {
-      if (menu.parentNode) menu.parentNode.removeChild(menu);
-      window.removeEventListener('click', removeMenu);
-    };
-    setTimeout(() => window.addEventListener('click', removeMenu), 0);
-  }, [isDarkMode]);
-
-  // Status bar mode update (Vim)
+  // Re-initialize Vim mode when toggled
   useEffect(() => {
-    if (!editorRef.current || !editorRef.current.view) return;
-    const cm = editorRef.current.view;
-    // Listen for Vim mode changes
-    const handler = (event) => {
-      if (event && event.mode) {
-        setStatus((s) => ({ ...s, mode: event.mode.toUpperCase() }));
+    if (editorRef.current) {
+      if (vimMode) {
+        if (vimModeRef.current) vimModeRef.current.dispose();
+        vimModeRef.current = initVimMode(editorRef.current, document.getElementById('vim-status-bar'));
+        vimModeRef.current.onDidChangeStatus((vimStatus) => {
+          setStatus((s) => ({ ...s, vimStatus }));
+        });
+      } else if (vimModeRef.current) {
+        vimModeRef.current.dispose();
+        vimModeRef.current = null;
       }
-    };
-    window.CodeMirror && window.CodeMirror.on && window.CodeMirror.on(cm, 'vim-mode-change', handler);
-    return () => {
-      window.CodeMirror && window.CodeMirror.off && window.CodeMirror.off(cm, 'vim-mode-change', handler);
-    };
-  }, []);
+      setStatus((s) => ({ ...s, vim: vimMode }));
+    }
+  }, [vimMode]);
 
-  // Command palette filtered commands
-  const filteredCommands = COMMANDS.filter(cmd =>
-    cmd.label.toLowerCase().includes(paletteQuery.toLowerCase())
-  );
+  // Custom actions: format, go to definition, find references, etc.
+  function runEditorAction(action) {
+    if (editorRef.current) {
+      editorRef.current.trigger('keyboard', action, null);
+    }
+  }
 
-  // Editor extensions
-  const extensions = [
-    lineNumbers(),
-    highlightActiveLineGutter(),
-    highlightSpecialChars(),
-    drawSelection(),
-    EditorView.lineWrapping,
-    highlightActiveLine(),
-    rectangularSelection(),
-    history(),
-    keymap.of([
-      ...defaultKeymap,
-      ...historyKeymap,
-      ...searchKeymap,
-      ...foldKeymap,
-      ...completionKeymap,
-      indentWithTab,
-    ]),
-    foldGutter(),
-    highlightSelectionMatches(),
-    autocompletion(),
-    bracketMatching(),
-    closeBrackets(),
-    vim(),
-    javascript(),
-    EditorView.updateListener.of(handleUpdate),
-  ];
+  function handleThemeChange(newTheme) {
+    setTheme(newTheme);
+  }
+
+  function handleToggleOption(optionKey) {
+    setEditorOptions((opts) => {
+      const newOpts = { ...opts };
+      if (typeof opts[optionKey] === 'object') {
+        newOpts[optionKey].enabled = !opts[optionKey].enabled;
+      } else if (typeof opts[optionKey] === 'boolean') {
+        newOpts[optionKey] = !opts[optionKey];
+      } else if (optionKey === 'lineNumbers') {
+        newOpts.lineNumbers = opts.lineNumbers === 'on' ? 'off' : 'on';
+      } else if (optionKey === 'wordWrap') {
+        newOpts.wordWrap = opts.wordWrap === 'on' ? 'off' : 'on';
+      }
+      return newOpts;
+    });
+  }
+
+  function handleInsertSnippet(snippet) {
+    if (editorRef.current) {
+      editorRef.current.trigger('keyboard', 'type', { text: snippet });
+      setShowSnippetMenu(false);
+    }
+  }
+
+  function handleAddVimRemap(from, to) {
+    setVimRemaps((remaps) => [...remaps, { from, to }]);
+    setShowVimRemapMenu(false);
+    // Optionally, apply remap to monaco-vim here
+  }
+
+  function handleDownload() {
+    const blob = new Blob([value], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function handleUpload(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+      if (onChange) onChange(evt.target.result);
+      setFileName(file.name);
+    };
+    reader.readAsText(file);
+  }
+
+  // Diagnostics (errors/warnings)
+  useEffect(() => {
+    if (editorRef.current) {
+      const model = editorRef.current.getModel();
+      if (model) {
+        import('monaco-editor').then(monaco => {
+          setDiagnostics(monaco.editor.getModelMarkers({ resource: model.uri }));
+        });
+      }
+    }
+  }, [value, language]);
 
   return (
-    <div onContextMenu={handleContextMenu} style={{ height: '100%', width: '100%', position: 'relative' }}>
-      <CodeMirror
-        ref={editorRef}
-        value={value}
+    <div style={{ height: '100%', width: '100%', position: 'relative' }}>
+      <MonacoEditor
         height="100%"
-        theme={vscodeDark}
-        extensions={extensions}
-        onChange={onChange}
-        style={{
-          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-          fontSize,
-          background: isDarkMode ? '#1e1e1e' : '#fff',
-          color: isDarkMode ? '#d4d4d4' : '#222',
-          minHeight: 0,
-        }}
+        defaultLanguage={language}
+        language={language}
+        value={value}
+        onChange={handleEditorChange}
+        onMount={handleEditorDidMount}
+        theme={theme}
+        options={editorOptions}
         {...rest}
       />
+      {/* Theme Switcher */}
+      <div style={{ position: 'absolute', top: 8, left: 8, zIndex: 10002 }}>
+        <select value={theme} onChange={e => handleThemeChange(e.target.value)} title="Switch Theme">
+          {THEMES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+        </select>
+      </div>
+      {/* Snippet Menu */}
+      {showSnippetMenu && (
+        <div style={{ position: 'absolute', top: 40, left: 40, zIndex: 10001, background: isDarkMode ? '#23272e' : '#fff', color: isDarkMode ? '#fff' : '#222', border: '1px solid #444', borderRadius: 8, boxShadow: '0 4px 32px rgba(0,0,0,0.25)', minWidth: 200, maxHeight: 400, overflowY: 'auto' }}>
+          <div style={{ padding: 12, fontWeight: 600 }}>Insert Snippet</div>
+          <button style={{ padding: '8px 16px', width: '100%', textAlign: 'left', background: 'none', border: 'none', color: 'inherit', cursor: 'pointer' }} onClick={() => handleInsertSnippet('console.log($1);')}>console.log()</button>
+          <button style={{ padding: '8px 16px', width: '100%', textAlign: 'left', background: 'none', border: 'none', color: 'inherit', cursor: 'pointer' }} onClick={() => handleInsertSnippet('function $1() {\n  $2\n}')}>function</button>
+          <button style={{ padding: '8px 16px', width: '100%', textAlign: 'left', background: 'none', border: 'none', color: 'inherit', cursor: 'pointer' }} onClick={() => handleInsertSnippet('if ($1) {\n  $2\n}')}>if statement</button>
+          {/* Add more snippets as needed */}
+        </div>
+      )}
+      {/* Vim Remap Menu */}
+      {showVimRemapMenu && (
+        <div style={{ position: 'absolute', top: 80, left: 40, zIndex: 10001, background: isDarkMode ? '#23272e' : '#fff', color: isDarkMode ? '#fff' : '#222', border: '1px solid #444', borderRadius: 8, boxShadow: '0 4px 32px rgba(0,0,0,0.25)', minWidth: 300, maxHeight: 400, overflowY: 'auto', padding: 16 }}>
+          <div style={{ fontWeight: 600, marginBottom: 8 }}>Add Vim Key Remap</div>
+          <form onSubmit={e => { e.preventDefault(); handleAddVimRemap(e.target.from.value, e.target.to.value); }}>
+            <input name="from" placeholder="From (e.g. jj)" style={{ marginRight: 8 }} />
+            <input name="to" placeholder="To (e.g. <Esc>)" style={{ marginRight: 8 }} />
+            <button type="submit">Add</button>
+          </form>
+          <div style={{ marginTop: 12 }}>
+            {vimRemaps.map((r) => <div key={r.from + '->' + r.to}>{r.from} → {r.to}</div>)}
+          </div>
+        </div>
+      )}
+      {/* File Upload (hidden input) */}
+      <input type="file" style={{ display: 'none' }} id="vim-upload-input" onChange={handleUpload} />
       {/* Status Bar */}
-      <div style={{
+      <div id="vim-status-bar" style={{
         position: 'absolute',
         bottom: 0,
         left: 0,
@@ -205,66 +261,35 @@ const VimCodeEditor = ({
         zIndex: 2,
         userSelect: 'none',
       }}>
-        <span style={{ marginRight: 16 }}><b>{status.mode}</b></span>
         <span style={{ marginRight: 16 }}>Ln {status.line}, Col {status.col}</span>
         <span style={{ marginRight: 16 }}>{status.language}</span>
-        <span style={{ marginLeft: 'auto', opacity: 0.7 }}>Vim Mode • Ctrl+Shift+P</span>
+        <span style={{ marginRight: 16 }}>
+          {status.vim && status.vimStatus
+            ? `Vim Mode • ${status.vimStatus} (Ctrl+Alt+V)`
+            : status.vim
+              ? 'Vim Mode (Ctrl+Alt+V)'
+              : 'Insert Mode (Ctrl+Alt+V to toggle Vim)'}
+        </span>
+        <button style={{ marginRight: 16 }} onClick={() => setShowSnippetMenu(v => !v)} title="Insert Snippet">Snippet</button>
+        <button style={{ marginRight: 16 }} onClick={() => setShowVimRemapMenu(v => !v)} title="Vim Remap">Vim Remap</button>
+        <button style={{ marginRight: 16 }} onClick={handleDownload} title="Download File">Download</button>
+        <button style={{ marginRight: 16 }} onClick={() => document.getElementById('vim-upload-input').click()} title="Upload File">Upload</button>
+        <button style={{ marginRight: 16 }} onClick={() => runEditorAction('editor.action.startFindReplaceAction')} title="Find/Replace (Ctrl+H)">Find/Replace</button>
+        <button style={{ marginRight: 16 }} onClick={() => runEditorAction('editor.action.insertCursorBelow')} title="Add Cursor Below (Ctrl+Alt+Down)">+Cursor</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('minimap')} title="Toggle Minimap">Minimap</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('lineNumbers')} title="Toggle Line Numbers">Line #</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('wordWrap')} title="Toggle Word Wrap">Wrap</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('codeLens')} title="Toggle Code Lens">CodeLens</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('folding')} title="Toggle Folding">Folding</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('renderWhitespace')} title="Toggle Whitespace">Whitespace</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('bracketPairColorization')} title="Toggle Bracket Colors">Brackets</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('guides')} title="Toggle Indent Guides">Guides</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('inlayHints')} title="Toggle Inlay Hints">Inlay</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('hover')} title="Toggle Hover">Hover</button>
+        <button style={{ marginRight: 16 }} onClick={() => handleToggleOption('contextmenu')} title="Toggle Context Menu">Context</button>
+        <span style={{ marginRight: 16, color: diagnostics.length ? 'red' : 'inherit' }} title="Problems">Problems: {diagnostics.length}</span>
+        <span style={{ marginLeft: 'auto', opacity: 0.7 }}>Monaco Editor • Ctrl+Shift+P</span>
       </div>
-      {/* Command Palette */}
-      {showPalette && (
-        <div style={{
-          position: 'absolute',
-          top: '20%',
-          left: '50%',
-          transform: 'translate(-50%, 0)',
-          background: isDarkMode ? '#23272e' : '#fff',
-          color: isDarkMode ? '#fff' : '#222',
-          border: '1px solid #444',
-          borderRadius: '8px',
-          boxShadow: '0 4px 32px rgba(0,0,0,0.25)',
-          zIndex: 10000,
-          minWidth: 340,
-          maxWidth: 480,
-        }}>
-          <input
-            autoFocus
-            value={paletteQuery}
-            onChange={e => setPaletteQuery(e.target.value)}
-            placeholder="Type a command..."
-            style={{
-              width: '100%',
-              padding: '12px 16px',
-              border: 'none',
-              outline: 'none',
-              background: 'inherit',
-              color: 'inherit',
-              fontSize: 16,
-              borderTopLeftRadius: 8,
-              borderTopRightRadius: 8,
-            }}
-            onKeyDown={e => {
-              if (e.key === 'Escape') setShowPalette(false);
-            }}
-          />
-          <div style={{ maxHeight: 260, overflowY: 'auto' }}>
-            {filteredCommands.length === 0 && (
-              <div style={{ padding: 16, opacity: 0.6 }}>No commands found</div>
-            )}
-            {filteredCommands.map((cmd, i) => (
-              <div
-                key={cmd.label}
-                style={{ padding: '10px 18px', cursor: 'pointer', borderBottom: '1px solid #333', background: i === 0 ? (isDarkMode ? '#333' : '#f0f0f0') : 'inherit' }}
-                onClick={() => {
-                  setShowPalette(false);
-                  if (cmd.action) { cmd.action(editorRef.current?.view); }
-                }}
-              >
-                {cmd.label}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/screens/ChatRaj.jsx
+++ b/frontend/src/screens/ChatRaj.jsx
@@ -837,45 +837,46 @@ const ChatRaj = () => {
               onClick={() => setIsSettingsOpen(false)}
             />
             <motion.div
-              initial={{ opacity: 0, x: -300 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -300 }}
-              className="fixed bottom-24 left-4 z-50 w-[320px] bg-white rounded-lg shadow-xl dark:bg-gray-800"
+              initial={{ opacity: 0, y: 40 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 40 }}
+              className="fixed bottom-24 left-8 z-50 w-[480px] max-w-full bg-white rounded-xl shadow-2xl dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
               style={{ 
                 maxHeight: 'calc(100vh - 180px)',
-                overflow: 'hidden'
+                overflow: 'hidden',
+                transition: 'box-shadow 0.18s',
               }}
             >
-              <div className="sticky top-0 z-10 flex items-center justify-between p-4 bg-white border-b dark:bg-gray-800 dark:border-gray-700">
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{t('settings')}</h2>
+              <div className="sticky top-0 z-10 flex items-center justify-between px-7 py-4 bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">{t('settings')}</h2>
                 <button 
                   onClick={() => setIsSettingsOpen(false)}
                   className="p-2 text-gray-500 rounded-lg hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
                 >
-                  <i className="text-xl ri-close-line"></i>
+                  <i className="text-2xl ri-close-line"></i>
                 </button>
               </div>
 
-              <div className="p-4 border-b dark:border-gray-700">
-                <div className="grid grid-cols-4 gap-1 p-1 bg-gray-100 rounded-lg dark:bg-gray-700">
-                  {['display', 'behavior', 'accessibility', 'sidebar', 'privacy'].map(tab => (
-                    <button
-                      key={tab}
-                      onClick={() => setActiveSettingsTab(tab)}
-                      className={`py-2 text-sm font-medium rounded-md transition-colors ${
-                        activeSettingsTab === tab 
-                          ? 'bg-white text-blue-600 shadow dark:bg-gray-600 dark:text-blue-400'
-                          : 'text-gray-600 hover:text-blue-600 dark:text-gray-300 dark:hover:text-blue-400'
-                      }`}
-                    >
-                      {tab.charAt(0).toUpperCase() + tab.slice(1)}
-                    </button>
-                  ))}
-                </div>
+              {/* Horizontal tab bar */}
+              <div className="flex border-b dark:border-gray-700 bg-gray-100 dark:bg-gray-700 px-7">
+                {['display', 'behavior', 'accessibility', 'sidebar', 'privacy'].map(tab => (
+                  <button
+                    key={tab}
+                    onClick={() => setActiveSettingsTab(tab)}
+                    className={`px-6 py-3 text-base font-semibold border-b-4 transition-colors duration-150 focus:outline-none ${
+                      activeSettingsTab === tab 
+                        ? 'border-blue-600 text-blue-600 bg-white dark:bg-gray-800 dark:text-blue-400' 
+                        : 'border-transparent text-gray-600 hover:text-blue-600 dark:text-gray-300 dark:hover:text-blue-400 bg-transparent'
+                    }`}
+                    style={{ marginBottom: '-1px', borderRadius: '10px 10px 0 0' }}
+                  >
+                    {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                  </button>
+                ))}
               </div>
 
               <div className="flex-1 overflow-y-auto">
-                <div className="p-4 space-y-6">
+                <div className="p-7 space-y-7">
                   {activeSettingsTab === 'display' && (
                     <div className="space-y-6">
                       <div className="flex items-center justify-between">

--- a/frontend/src/screens/Project.jsx
+++ b/frontend/src/screens/Project.jsx
@@ -16,6 +16,7 @@ import PropTypes from 'prop-types';
 import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 import { vim } from '@replit/codemirror-vim';
+import VimCodeEditor from '../components/VimCodeEditor';
 
 function deduplicateMessages(messages) {
   const seen = new Set();
@@ -529,7 +530,6 @@ const Project = () => {
             </div>
             {Object.entries(reactionGroups).map(([emoji, users]) => {
               if (users.length === 0) return null;
-              
               return (
                 <button
                   key={emoji}
@@ -924,41 +924,61 @@ const Project = () => {
                   <div>fileTree[currentFile]?.file?.contents length: {fileTree[currentFile]?.file?.contents?.length ?? 'N/A'}</div>
                 </div>
               )}
-              {fileTree && currentFile && fileTree[currentFile] && fileTree[currentFile].file && typeof fileTree[currentFile].file.contents === 'string' && fileTree[currentFile].file.contents.length > 0 ? (
+              {fileTree && currentFile && fileTree[currentFile]?.file?.contents?.length > 0 ? (
                 <div style={{ flex: 1, minHeight: 0, width: '100%', display: 'flex', flexDirection: 'column', overflow: 'auto' }}>
-                  <CodeMirror
-                    className={settings.display.syntaxHighlighting === false && isDarkMode ? "syntax-off-dark" : ""}
-                    value={fileTree[currentFile].file.contents}
-                    theme={settings.display.syntaxHighlighting === false ? undefined : (isDarkMode ? 'dark' : 'light')}
-                    extensions={
-                      settings.display.syntaxHighlighting === false
-                        ? []
-                        : [
-                            javascript(),
-                            vimMode ? vim() : [],
-                          ]
-                    }
-                    onChange={(value) => {
-                      const ft = { ...fileTree, [currentFile]: { file: { contents: value } } }
-                      setFileTree(ft)
-                    }}
-                    basicSetup={{
-                      lineNumbers: true,
-                      highlightActiveLine: true,
-                      highlightActiveLineGutter: true,
-                    }}
-                    style={{
-                      fontSize: settings.display.messageFontSize === 'large' ? '1.2rem' : settings.display.messageFontSize === 'small' ? '0.9rem' : '1rem',
-                      background: settings.display.syntaxHighlighting === false && isDarkMode
-                        ? '#181e29'
-                        : isDarkMode
-                        ? '#111827'
-                        : 'white',
-                      color: settings.display.syntaxHighlighting === false && isDarkMode ? '#fff' : undefined,
-                      height: '100%',
-                      minHeight: 0,
-                    }}
-                  />
+                  {vimMode ? (
+                    <VimCodeEditor
+                      value={fileTree[currentFile].file.contents}
+                      onChange={(value) => {
+                        setFileTree((prev) => ({
+                          ...prev,
+                          [currentFile]: {
+                            ...prev[currentFile],
+                            file: { ...prev[currentFile].file, contents: value },
+                          },
+                        }));
+                      }}
+                      isDarkMode={isDarkMode}
+                      fontSize={settings.display.messageFontSize === 'large' ? '1.2rem' : settings.display.messageFontSize === 'small' ? '0.9rem' : '1rem'}
+                    />
+                  ) : (
+                    <CodeMirror
+                      className={settings.display.syntaxHighlighting === false && isDarkMode ? 'syntax-off-dark' : ''}
+                      value={fileTree[currentFile].file.contents}
+                      theme={settings.display.syntaxHighlighting === false ? undefined : (isDarkMode ? 'dark' : 'light')}
+                      extensions={
+                        settings.display.syntaxHighlighting === false
+                          ? []
+                          : [javascript()]
+                      }
+                      onChange={(value) => {
+                        setFileTree((prev) => ({
+                          ...prev,
+                          [currentFile]: {
+                            ...prev[currentFile],
+                            file: { ...prev[currentFile].file, contents: value },
+                          },
+                        }));
+                      }}
+                      basicSetup={{
+                        lineNumbers: true,
+                        highlightActiveLine: true,
+                        highlightActiveLineGutter: true,
+                      }}
+                      style={{
+                        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                        fontSize: settings.display.messageFontSize === 'large' ? '1.2rem' : settings.display.messageFontSize === 'small' ? '0.9rem' : '1rem',
+                        background: settings.display.syntaxHighlighting === false && isDarkMode
+                          ? '#181e29'
+                          : isDarkMode
+                          ? '#111827'
+                          : 'white',
+                        color: settings.display.syntaxHighlighting === false && isDarkMode ? '#fff' : undefined,
+                        height: '100%',
+                        minHeight: 0,
+                      }}
+                    />
+                  )}
                 </div>
               ) : (
                 <div className="flex items-center justify-center h-full min-h-[200px] text-gray-400 italic select-none" style={{padding:'2rem'}}>


### PR DESCRIPTION
Add Options menu for vim editor in the Project.jsx.

## Summary by Sourcery

Introduce a unified options menu for the Vim editor in Project.jsx and replace the CodeMirror-based VimCodeEditor with a Monaco-based implementation featuring Vim mode via monaco-vim, category-driven settings, snippet insertion, key remaps, and diagnostics. Update settings modals across Project.jsx and ChatRaj.jsx for improved styling and draggable behavior, and add necessary Monaco and ReactModal dependencies.

New Features:
- Add Options button and compact options modal in the project explorer to configure editor preferences
- Replace CodeMirror with a Monaco-based VimCodeEditor including Vim mode integration via monaco-vim
- Implement category-driven editor options modal inside VimCodeEditor with toggles, select controls, and action buttons
- Add snippet insertion and Vim key remap UIs within VimCodeEditor
- Display diagnostic marker count in the editor status bar

Enhancements:
- Refactor Project.jsx settings modal to be draggable and center-aligned
- Standardize horizontal tab bar and styling in ChatRaj.jsx settings
- Streamline settings panels in both screens with updated spacing and transitions

Chores:
- Add @monaco-editor/react, monaco-editor, monaco-vim, and react-modal to dependencies