### PR TITLE
fix auto-merge commit message.

### DIFF
--- a/.github/workflows/close-pr-on-failure.yml
+++ b/.github/workflows/close-pr-on-failure.yml
@@ -1,35 +1,29 @@
 name: Close PRs on Production Deployment Failure
 
 on:
-  deployment_status:
+  deployment_status
+
+permissions:
+  pull-requests: write
 
 jobs:
-  close-pr-on-failure:
-    if: |
-      github.event.deployment_status.state == 'failure' ||
-      github.event.deployment_status.state == 'error' ||
-      github.event.deployment_status.state == 'inactive'
+  close-failed-pr:
+    if: github.event.deployment_status.state == 'failure'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            if (context.payload.deployment.environment !== 'production') return;
+      - name: Close PR using GitHub REST API
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_url=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+            https://api.github.com/repos/${{ github.repository }}/deployments/${{ github.event.deployment_status.deployment.id }}/statuses \
+            | jq -r '.[0].target_url')
 
-            const prs = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100
-            });
+          pr_number=$(echo "$pr_url" | grep -oE '[0-9]+$')
 
-            for (const pr of prs) {
-              if (pr.head.sha === context.payload.deployment.sha) {
-                await github.rest.pulls.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                  state: 'closed'
-                });
-              }
-            }
+          if [[ "$pr_number" != "" ]]; then
+            curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/${{ github.repository }}/pulls/$pr_number \
+              -d '{"state":"closed"}'
+          fi

--- a/.github/workflows/enable-auto-merge.yml
+++ b/.github/workflows/enable-auto-merge.yml
@@ -2,23 +2,24 @@ name: Enable Auto-Merge
 
 on:
   pull_request_target:
-    types: [labeled]
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
 
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:
   enable-auto-merge:
     if: |
-      github.actor == github.event.pull_request.user.login &&
-      contains(github.event.pull_request.labels.*.name, 'automerge')
+      github.actor == 'Abhirajgautam28' &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'automerge')
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge
+      - name: Enable auto-merge for PR
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
-          merge-method: squash
-          
+          merge-method: SQUASH

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,10 +2,9 @@ name: Label PRs for Auto-Merge
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize]
 
 permissions:
-  contents: read
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
fix auto-merge commit message.

## Summary by Sourcery

Revise GitHub Actions workflows to streamline PR auto-merge and failure-handling by adjusting triggers, permissions, and closure logic.

Enhancements:
- Refine close-pr-on-failure workflow by adding pull-requests write permission, narrowing to failed deployments, renaming the job, and replacing GitHub Script with direct REST API calls
- Enhance enable-auto-merge workflow by broadening pull_request_target triggers, updating actor and label conditions, removing explicit merge-method, and simplifying permissions
- Reorder event types in the labeler workflow for consistency