### PR TITLE
Fix reset password functionality by adding OTP sending endpoint.

### DIFF
--- a/Backend/routes/user.routes.js
+++ b/Backend/routes/user.routes.js
@@ -1,4 +1,3 @@
-
 import { Router } from 'express';
 import * as userController from '../controllers/user.controller.js';
 import { body } from 'express-validator';


### PR DESCRIPTION
Fix reset password functionality by adding OTP sending endpoint.

## Summary by Sourcery

Improve the password reset flow by adding OTP sending and resend functionality on the frontend and sending a confirmation email on the backend after successful password update.

New Features:
- Add OTP resend button with a 30-second cooldown timer in the reset password UI
- Send a styled HTML password reset success email to users after their password is updated

Enhancements:
- Disable the OTP send/resend buttons during the cooldown period to prevent multiple requests