### PR TITLE
fix: Address code review comments for chatbot modal.

### DIFF
--- a/frontend/src/screens/Home.jsx
+++ b/frontend/src/screens/Home.jsx
@@ -1,6 +1,6 @@
 import ProjectShowcase from '../components/ProjectShowcase.jsx';
 import UserLeaderboard from '../components/UserLeaderboard.jsx';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState, lazy, Suspense } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { UserContext } from '../context/user.context';
@@ -9,7 +9,7 @@ import NewsletterSubscribeForm from '../components/NewsletterSubscribeForm.jsx';
 // ...existing code...
 import Blog from '../components/Blog.jsx';
 import ContactUs from '../components/ContactUs.jsx';
-import AskChatRajModal from '../components/AskChatRajModal.jsx';
+const AskChatRajModal = lazy(() => import('../components/AskChatRajModal.jsx'));
 
 // Newsletter API endpoint for subscription
 const NEWSLETTER_API_URL =
@@ -645,10 +645,14 @@ function greet(name) {
         <p className={`${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>© 2025 ChatRaj All rights reserved.</p>
       </footer>
 
-      <AskChatRajModal
-        isOpen={showAskChatRajModal}
-        onRequestClose={() => setShowAskChatRajModal(false)}
-      />
+      <Suspense fallback={<div>Loading...</div>}>
+        {showAskChatRajModal && (
+          <AskChatRajModal
+            isOpen={showAskChatRajModal}
+            onRequestClose={() => setShowAskChatRajModal(false)}
+          />
+        )}
+      </Suspense>
     </div>
   );
 };

--- a/frontend/src/styles/AskChatRajModal.css
+++ b/frontend/src/styles/AskChatRajModal.css
@@ -33,7 +33,6 @@
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
 }
 
@@ -45,7 +44,11 @@
   background: none;
   border: none;
   font-size: 1.5rem;
+  margin-left: auto;
+  padding: 0.25rem 0.5rem;
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .ask-chat-raj-modal-body {


### PR DESCRIPTION
fix: Address code review comments for chatbot modal.

## Summary by Sourcery

Implement lazy loading for the chatbot modal, wrap it in Suspense with a fallback, conditionally render it only when open, and refine its close button styling.

Enhancements:
- Lazily import AskChatRajModal using React.lazy and wrap its rendering in Suspense with a loading fallback
- Render the chatbot modal only when the showAskChatRajModal flag is true
- Adjust modal CSS by removing justify-content and updating the close button’s margin, padding, and flex alignment