### PR TITLE
Fix darkMode prop usage in MaterialBlogCard component.

### DIFF
--- a/frontend/src/components/MaterialBlogCard.jsx
+++ b/frontend/src/components/MaterialBlogCard.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import 'remixicon/fonts/remixicon.css';
 
-const MaterialBlogCard = ({ blog, darkMode }) => (
+const MaterialBlogCard = ({ blog }) => (
   <div
     className={`rounded-xl shadow-md bg-white dark:bg-gray-900 hover:shadow-lg transition-shadow duration-200 flex flex-col h-full border border-gray-200 dark:border-gray-800 max-w-md mx-auto`}
     style={{ minWidth: 0 }}
   >
     <div className="p-0">
       {blog.coverImage && (
-        <img src={blog.coverImage} alt={blog.title} className="rounded-t-xl w-full h-48 object-cover" />
+        <img src={blog.coverImage} alt={`Cover image for ${blog.title}`} className="rounded-t-xl w-full h-48 object-cover" />
       )}
     </div>
     <div className="flex-1 flex flex-col p-5">

--- a/frontend/src/hooks/useDarkMode.js
+++ b/frontend/src/hooks/useDarkMode.js
@@ -18,6 +18,19 @@ const useDarkMode = (key = 'blog_dark_mode', defaultValue = false) => {
         document.documentElement.classList.remove('dark');
       }
       localStorage.setItem(key, darkMode);
+
+      // Subscribe to system theme changes
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      const handleChange = (e) => {
+        // Only update if user hasn't set a preference
+        if (localStorage.getItem(key) === null) {
+          setDarkMode(e.matches);
+        }
+      };
+      mediaQuery.addEventListener('change', handleChange);
+      return () => {
+        mediaQuery.removeEventListener('change', handleChange);
+      };
     }
   }, [darkMode, key]);
 


### PR DESCRIPTION
Fix darkMode prop usage in the MaterialBlogCard component.

## Summary by Sourcery

Subscribe to system theme changes in useDarkMode hook, remove unused darkMode prop from MaterialBlogCard component, and improve image alt text for accessibility.

Enhancements:
- Subscribe to system color scheme changes in the dark mode hook to auto-update theme when user hasn’t set a preference
- Remove unused darkMode prop from MaterialBlogCard component
- Enhance blog cover image alt text for better accessibility