### PR TITLE
Fix dark mode background to a gradient.

### DIFF
--- a/frontend/src/components/ProjectShowcase.jsx
+++ b/frontend/src/components/ProjectShowcase.jsx
@@ -25,7 +25,7 @@ const ProjectShowcase = () => {
     }
 
     return (
-    <div className="p-6 bg-white rounded-lg shadow-md dark:bg-gradient-to-br dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+    <div className="p-6 rounded-lg shadow-md bg-white dark:bg-transparent dark:bg-dark-gradient">
             <h3 className="mb-4 text-xl font-semibold text-gray-800 dark:text-white">Project Showcase</h3>
             <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
                 {Array.isArray(projects) && projects.map(project => (

--- a/frontend/src/components/UserLeaderboard.jsx
+++ b/frontend/src/components/UserLeaderboard.jsx
@@ -25,7 +25,7 @@ const UserLeaderboard = () => {
     }
 
     return (
-    <div className="p-6 bg-white rounded-lg shadow-md dark:bg-gradient-to-br dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+    <div className="p-6 rounded-lg shadow-md bg-white dark:bg-transparent dark:bg-dark-gradient">
             <h3 className="mb-4 text-xl font-semibold text-gray-800 dark:text-white">User Leaderboard</h3>
             <ul className="space-y-4">
                 {Array.isArray(users) && users.map((user, index) => (

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -11,7 +11,10 @@ export default {
         gray: {
           850: '#1f2937',
         }
-      }
+      },
+      backgroundImage: {
+        'dark-gradient': 'linear-gradient(135deg, #111827 0%, #1f2937 50%, #111827 100%)',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Fix dark mode background to a gradient.

## Summary by Sourcery

Define and apply a custom dark-mode gradient background across card components

Enhancements:
- Add ‘dark-gradient’ backgroundImage in Tailwind config
- Replace individual dark gradient utilities with ‘dark:bg-dark-gradient’ in ProjectShowcase and UserLeaderboard