### PR TITLE
Modify compose.yaml to change the host port mapping.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     environment:
       NODE_ENV: production
     ports:
-      - 8080:8080
+      - 8081:8080
     depends_on:
       - mongo
       - redis

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,16 +32,12 @@ services:
   mongo:
     image: mongo:7
     restart: always
-    ports:
-      - 27017:27017
     networks:
       - chatraj-net
 
   redis:
     image: redis:7
     restart: always
-    ports:
-      - 6379:6379
     networks:
       - chatraj-net
 


### PR DESCRIPTION
Modify compose.yaml to change the host port mapping.

## Summary by Sourcery

Update Docker Compose port configurations by adjusting the host port for the app service and removing external port exposure for database services.

Enhancements:
- Change app service host port mapping from 8080:8080 to 8081:8080
- Remove host port bindings for mongo and redis services in compose.yaml