### PR TITLE
Fix prop-types validation for 'text' prop in TextType component

### DIFF
--- a/frontend/src/components/TextType.jsx
+++ b/frontend/src/components/TextType.jsx
@@ -149,6 +149,9 @@ const TextType = ({
     const shouldHideCursor =
         hideCursorWhileTyping && (currentCharIndex < textArray[currentTextIndex].length || isDeleting);
 
+    // compute current color once to avoid redundant calls in render
+    const currentColor = getCurrentTextColor();
+
     return createElement(
         Component,
         {
@@ -157,8 +160,8 @@ const TextType = ({
             ...props
         },
         <span
-            className="inline"
-            style={getCurrentTextColor() ? { color: getCurrentTextColor() } : undefined}
+            className={`inline ${currentColor ? '' : 'text-current'}`}
+            style={currentColor ? { color: currentColor } : undefined}
         >
             {displayedText}
         </span>,
@@ -176,7 +179,7 @@ const TextType = ({
 export default TextType;
 
 TextType.propTypes = {
-    text: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired,
+    text: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]).isRequired,
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
     typingSpeed: PropTypes.number,
     initialDelay: PropTypes.number,


### PR DESCRIPTION
Fix prop-types validation for 'text' prop in TextType component.

## Summary by Sourcery

Fix prop-types validation for the 'text' prop in TextType and optimize text color rendering.

Bug Fixes:
- Restrict 'text' prop to be either a string or an array of strings in TextType component

Enhancements:
- Cache the computed text color in a variable to avoid redundant calls
- Update span className to include 'text-current' when no explicit color is provided