### PR TITLE
chore(frontend): upgrade dompurify via override to >=3.2.4 to fix Dependabot XSS advisory

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "antd": "^5.27.4",
         "axios": "^1.12.2",
         "bootstrap": "^5.3.8",
+        "dompurify": "^3.2.4",
         "framer-motion": "^12.23.24",
         "gsap": "^3.13.0",
         "highlight.js": "^11.11.1",
@@ -6287,6 +6288,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/warning": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
@@ -9849,10 +9857,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "masonry-layout": "^4.2.2",
     "monaco-editor": "^0.54.0",
     "monaco-vim": "^0.4.2",
+  "dompurify": "^3.2.4",
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.10",
     "react-dnd": "^16.0.1",
@@ -78,5 +79,9 @@
     "tailwindcss": "3.4.3",
     "vite": "7.1.9",
     "vitest": "^3.2.4"
+  }
+  ,
+  "overrides": {
+    "dompurify": "^3.2.4"
   }
 }


### PR DESCRIPTION
chore(frontend): upgrade dompurify via override to >=3.2.4 to fix Dependabot XSS advisory

## Summary by Sourcery

Enforce upgrade of dompurify to version 3.2.4 in the frontend to resolve a Dependabot XSS advisory

Bug Fixes:
- Upgrade dompurify to 3.2.4 to address the security advisory for XSS

Build:
- Add npm override in package.json to enforce dompurify version >=3.2.4