### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure Dependabot to cap open pull requests for GitHub Actions updates at 10.