### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   smoke-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/62](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/62)

In general, this should be fixed by explicitly defining a `permissions:` block in the workflow so that the automatically provided `GITHUB_TOKEN` has only the minimal required scopes. Since none of the jobs perform repository writes (they only read code, run Node.js, and deploy via an external token), the workflow can safely set `contents: read` globally.

The best fix here is to add a top-level `permissions:` block (at the same indentation level as `on:` and `jobs:`) specifying `contents: read`. This will apply to all jobs (`smoke-test`, `tests`, and `deploy-staging`) because none of them define their own `permissions:`. No changes to individual steps are needed, and no additional libraries or actions are required. Concretely, in `.github/workflows/smoke-test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–5) and the `jobs:` block (line 7). This directly addresses the CodeQL warning and follows GitHub’s least-privilege recommendation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a top-level permissions block to the smoke-test workflow to limit GITHUB_TOKEN contents access to read-only.