### PR TITLE
Potential fix for code scanning alert no. 43: Insecure randomness

### DIFF
--- a/Backend/controllers/user.controller.js
+++ b/Backend/controllers/user.controller.js
@@ -34,6 +34,7 @@ import { validationResult } from 'express-validator';
 import redisClient from '../services/redis.service.js';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
 
 export const createUserController = async (req, res) => {
 
@@ -60,7 +61,8 @@ function generateOTP(length) {
     const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*';
     let otp = '';
     for (let i = 0; i < length; i++) {
-        otp += chars[Math.floor(Math.random() * chars.length)];
+        const index = crypto.randomInt(chars.length);
+        otp += chars[index];
     }
     return otp;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/43](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/43)

To fix this, replace the use of `Math.random()` in `generateOTP` with a cryptographically secure random generator provided by Node’s `crypto` module (for example `crypto.randomInt` or `crypto.randomBytes`). That way, each character in the OTP is chosen using secure randomness rather than a predictable PRNG, while preserving the function’s API and behavior (same length, same character set).

The best minimal change is:

- Import Node’s built‑in `crypto` module at the top of `Backend/controllers/user.controller.js`.
- Update `generateOTP(length)` so that instead of `Math.floor(Math.random() * chars.length)` it calls `crypto.randomInt(chars.length)` to pick a secure random index in the allowed range. This avoids writing custom bias‑prone logic and keeps the output format identical (7 characters from the same `chars` string).
- No changes are needed in `Backend/services/user.service.js`, since it only consumes the `otp` value.

Concretely:

- In `Backend/controllers/user.controller.js`, add `import crypto from 'crypto';` alongside existing imports.
- Replace the body of the `for` loop in `generateOTP` such that it calls `crypto.randomInt(chars.length)` to index into `chars`.
- Leave `createUser` and its use of `otp` unchanged; they will now benefit from the secure randomness used upstream.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace Math.random()-based OTP generation with Node crypto.randomInt to prevent insecure and predictable OTP values.