### PR TITLE
Potential fix for code scanning alert no. 15: Missing rate limiting

### DIFF
--- a/Backend/routes/newsletter.routes.js
+++ b/Backend/routes/newsletter.routes.js
@@ -1,9 +1,15 @@
 import express from 'express';
 import { subscribeNewsletter } from '../controllers/newsletter.controller.js';
+import rateLimit from 'express-rate-limit';
 
 const router = express.Router();
 
+const newsletterLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 subscription requests per windowMs
+});
+
 // POST /api/newsletter/subscribe
-router.post('/subscribe', subscribeNewsletter);
+router.post('/subscribe', newsletterLimiter, subscribeNewsletter);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/15](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/15)

In general, to fix missing rate limiting on an Express route that performs expensive operations (like DB writes), you should add a rate-limiting middleware. This middleware inspects incoming requests and rejects or delays them when a client exceeds a configured threshold within a time window. The middleware can be attached globally, per router, or per route; here we will attach it at the router level (and specifically to this route) to avoid changing global behavior.

For this file, the best minimal fix is:
- Import `express-rate-limit`.
- Define a rate limiter tailored for newsletter subscriptions, e.g., allowing a small number of subscription attempts per IP per time window.
- Apply this limiter to the `/subscribe` route by adding it as a middleware argument before `subscribeNewsletter`.

Concretely, in `Backend/routes/newsletter.routes.js`:
- Add a new import line for `express-rate-limit`.
- Create a `newsletterLimiter` constant using `rateLimit({ ... })` after the router is created.
- Change `router.post('/subscribe', subscribeNewsletter);` to `router.post('/subscribe', newsletterLimiter, subscribeNewsletter);`.

No changes to existing functionality are made beyond rejecting or slowing excessive requests.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Introduce an express-rate-limit middleware for the newsletter subscription route to cap the number of subscription attempts per IP within a time window.