### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/Backend/routes/blog.routes.js
+++ b/Backend/routes/blog.routes.js
@@ -8,14 +8,25 @@ import {
     generateBlogContent
 } from '../controllers/blog.controller.js';
 import { authUser } from '../middleware/auth.middleware.js';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const rateLimit = require('express-rate-limit');
 
 const router = Router();
+
+const generateContentLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 20, // limit each IP to 20 generate requests per windowMs
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false,  // Disable the `X-RateLimit-*` headers
+});
 
 router.post('/', authUser, createBlog);
 router.get('/', getAllBlogs);
 router.get('/:id', getBlogById);
 router.post('/like/:id', authUser, likeBlog);
 router.post('/comment/:id', authUser, commentOnBlog);
-router.post('/generate', authUser, generateBlogContent);
+router.post('/generate', generateContentLimiter, authUser, generateBlogContent);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/14](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/14)

In general, to fix missing rate limiting on an Express route, you add a rate-limiting middleware (for example, using `express-rate-limit`) and apply it either globally or specifically to sensitive/expensive routes. This middleware restricts how many requests a client (usually keyed by IP) can make within a defined time window, mitigating denial-of-service and brute-force style attacks.

For this file, the best fix with minimal behavioural changes is to introduce `express-rate-limit` and apply a specific limiter only to the `/generate` route. That directly protects the route CodeQL flagged without altering other blog routes’ behaviour. Concretely: (1) add an import (CommonJS-style `require` is typical for `express-rate-limit`, but in an ES module file we can use `createRequire` from `module` to safely `require` it without touching other imports); (2) define a `generateContentLimiter` configured to allow a reasonable number of requests per time window (e.g., 20 per 15 minutes) and perhaps return a standard 429 when exceeded; (3) insert this middleware in the `/generate` route before `authUser` and `generateBlogContent` so all traffic to that route is rate-limited. All other routes remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Introduce an express-rate-limit-based middleware and apply it to the /generate blog route to cap request frequency per IP.