### PR TITLE
Potential fix for code scanning alert no. 88: Missing rate limiting

### DIFF
--- a/Backend/routes/blog.routes.js
+++ b/Backend/routes/blog.routes.js
@@ -27,9 +27,14 @@ const likeRateLimiter = rateLimit({
     max: 200, // allow more frequent likes but still protect against abuse
 });
 
+const getBlogRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 300, // limit each IP to 300 blog fetch requests per windowMs
+});
+
 router.post('/', authUser, createBlog);
 router.get('/', getAllBlogs);
-router.get('/:id', getBlogById);
+router.get('/:id', getBlogRateLimiter, getBlogById);
 router.post('/like/:id', authUser, likeRateLimiter, likeBlog);
 router.post('/comment/:id', authUser, commentRateLimiter, commentOnBlog);
 router.post('/generate', authUser, generateRateLimiter, generateBlogContent);


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/88](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/88)

To fix the missing rate limiting, we should introduce a dedicated rate limiter for the `getBlogById` route, similar to the existing `commentRateLimiter`, `generateRateLimiter`, and `likeRateLimiter`. This keeps behavior consistent across database-backed routes and leverages the existing `express-rate-limit` import. The limiter should be applied only to this route (not globally) to avoid altering other endpoints’ behavior.

Concretely, in `Backend/routes/blog.routes.js`, define a new `getBlogRateLimiter` constant using `rateLimit(...)` near the other limiter definitions (around lines 25–28). Configure a sensible limit (e.g., same 15-minute window with a moderate `max`, such as 300 requests per IP per window) to protect the database while allowing normal usage. Then update the `router.get('/:id', getBlogById);` line (line 32) to insert this middleware: `router.get('/:id', getBlogRateLimiter, getBlogById);`. No new imports are needed because `express-rate-limit` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Introduce a dedicated rate limiter for the get-blog-by-id route to address missing rate limiting and reduce potential abuse of blog fetch requests.