### PR TITLE
Potential fix for code scanning alert no. 93: Missing rate limiting

### DIFF
--- a/Backend/routes/blog.routes.js
+++ b/Backend/routes/blog.routes.js
@@ -12,6 +12,11 @@ import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
+const createBlogRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50, // limit each IP to 50 blog creation requests per windowMs
+});
+
 const commentRateLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 100, // limit each IP to 100 comment requests per windowMs
@@ -37,7 +42,7 @@ const getAllBlogsRateLimiter = rateLimit({
     max: 300, // limit each IP to 300 list-all requests per windowMs
 });
 
-router.post('/', authUser, createBlog);
+router.post('/', authUser, createBlogRateLimiter, createBlog);
 router.get('/', getAllBlogsRateLimiter, getAllBlogs);
 router.get('/:id', getBlogRateLimiter, getBlogById);
 router.post('/like/:id', authUser, likeRateLimiter, likeBlog);


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/93](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/93)

To fix the problem, we should apply rate limiting to the `POST /` route that invokes `createBlog`, using the same `express-rate-limit` library already imported and used in this file. This keeps the approach consistent with the existing rate limiters and avoids changing any controller behavior.

Concretely, in `Backend/routes/blog.routes.js`, we will:
- Define a new `createBlogRateLimiter` constant using `rateLimit`, similar to `commentRateLimiter`, `generateRateLimiter`, etc. We can choose a relatively conservative maximum (e.g., 50–100 create requests per IP per 15 minutes) because blog creation is a heavier operation than reading or liking.
- Insert this definition alongside the other rate limiter definitions near the top of the file.
- Update the `router.post('/', authUser, createBlog);` line to include the new middleware: `router.post('/', authUser, createBlogRateLimiter, createBlog);`.

No new imports are needed, since `rateLimit` is already imported. No changes to other files or to controller implementations are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Apply a dedicated rate limiter to the blog creation route to mitigate abuse and align with existing rate-limited endpoints.