### PR TITLE
Potential fix for code scanning alert no. 94: Missing rate limiting

### DIFF
--- a/Backend/routes/blog.routes.js
+++ b/Backend/routes/blog.routes.js
@@ -42,11 +42,11 @@ const getAllBlogsRateLimiter = rateLimit({
     max: 300, // limit each IP to 300 list-all requests per windowMs
 });
 
-router.post('/', authUser, createBlogRateLimiter, createBlog);
+router.post('/', createBlogRateLimiter, authUser, createBlog);
 router.get('/', getAllBlogsRateLimiter, getAllBlogs);
 router.get('/:id', getBlogRateLimiter, getBlogById);
-router.post('/like/:id', authUser, likeRateLimiter, likeBlog);
-router.post('/comment/:id', authUser, commentRateLimiter, commentOnBlog);
-router.post('/generate', authUser, generateRateLimiter, generateBlogContent);
+router.post('/like/:id', likeRateLimiter, authUser, likeBlog);
+router.post('/comment/:id', commentRateLimiter, authUser, commentOnBlog);
+router.post('/generate', generateRateLimiter, authUser, generateBlogContent);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/94](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/94)

In general, expensive middleware (authorization, database-backed auth checks, etc.) should run only after a rate-limiting middleware has accepted the request. In Express, this is controlled simply by the order of middleware in the route definition: they are executed left-to-right. Currently, `authUser` comes before its corresponding rate limiter on the affected routes, so authorization likely hits the database before the limiter can reject abusive traffic.

The best fix, without changing existing behavior, is to reorder middleware so that the route-specific rate limiter runs immediately after the path and before `authUser`. This way, abusive or high-volume requests are rejected early, and `authUser` and the controller (which may both touch the database) are only invoked for requests that pass the rate limits. Concretely, in `Backend/routes/blog.routes.js`, update the affected `router.post` calls to place their `*RateLimiter` middleware before `authUser`. All required imports and limiter definitions already exist in the file; we just adjust the route definitions on lines 45, 48, 49, and 50.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Ensure blog creation, like, comment, and content-generation endpoints apply request rate limiting before running authentication middleware to address missing rate limiting on these routes.