### PR TITLE
Potential fix for code scanning alert no. 58: Database query built from user-controlled sources

### DIFF
--- a/Backend/services/project.service.js
+++ b/Backend/services/project.service.js
@@ -202,6 +202,9 @@ export const updateFileTree = async ({ projectId, fileTree, userId }) => {
     // Validate fileTree structure to prevent injection of MongoDB operators or invalid types
     validateFileTree(fileTree);
 
+    // Normalize to plain JSON to strip any unexpected prototypes or non-serializable values
+    const safeFileTree = JSON.parse(JSON.stringify(fileTree));
+
     if (userId) {
         const project = await projectModel.findOne({
             _id: projectId,
@@ -216,7 +219,7 @@ export const updateFileTree = async ({ projectId, fileTree, userId }) => {
     const project = await projectModel.findOneAndUpdate({
         _id: projectId
     }, {
-        fileTree
+        $set: { fileTree: safeFileTree }
     }, {
         new: true
     })


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/58](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/58)

In general, to fix this kind of issue you ensure that any user-controlled value used in a database query or update is (a) strictly validated and/or sanitized to a safe, literal form and (b) only passed to the database in contexts where it is interpreted as data, not as query or update operators. For MongoDB updates, that typically means: validate the structure, deep-clone/serialize it into plain JSON so no exotic prototypes remain, and embed it only under a literal field path (e.g. using `$set: { fileTree: sanitizedValue }`).

For this specific code, the best minimal fix that preserves existing behavior is:

1. Keep the existing `validateFileTree(fileTree)` call, since it already blocks operator-style keys and non-plain objects.
2. After validation, normalize `fileTree` into a plain JSON value so there is zero chance of accidentally passing a special object instance or prototype to Mongoose. A standard pattern is `JSON.parse(JSON.stringify(fileTree))`, which strips functions, symbols, and non-JSON types.
3. Use this sanitized `safeFileTree` in the `findOneAndUpdate` call, under a `$set` operator. This does not change semantics (it still just assigns the `fileTree` field) but makes the intent explicit and clearer to both humans and tools.

Only `Backend/services/project.service.js` needs modifying:

- In `updateFileTree`, right after `validateFileTree(fileTree);`, introduce `const safeFileTree = JSON.parse(JSON.stringify(fileTree));`.
- In the `findOneAndUpdate` call, update the second argument from `{ fileTree }` to `{ $set: { fileTree: safeFileTree } }`.

No change is needed in the controller beyond this, and no behavior change is expected other than stronger guarantees that `fileTree` is persisted as plain JSON.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Normalize validated fileTree data into a plain JSON value before updating the project document to avoid unsafe prototypes or non-serializable values.