### PR TITLE
Potential fix for code scanning alert no. 100: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/components/CreateBlogForm.jsx
+++ b/frontend/src/components/CreateBlogForm.jsx
@@ -94,28 +94,48 @@ const getYouTubeEmbedUrl = (urlString) => {
     if (!urlString) return '';
     try {
         const url = new URL(urlString);
+        // Only allow http/https schemes
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+            return '';
+        }
+        const hostname = url.hostname.toLowerCase();
+        const isYoutubeHost =
+            hostname === 'youtube.com' ||
+            hostname === 'www.youtube.com' ||
+            hostname === 'm.youtube.com';
+        const isShortHost =
+            hostname === 'youtu.be' ||
+            hostname === 'www.youtu.be';
+
         let videoId = '';
-        if (url.hostname === 'youtu.be') {
+
+        if (isShortHost) {
             videoId = url.pathname.slice(1);
-        } else if (url.hostname.includes('youtube.com')) {
+        } else if (isYoutubeHost) {
             if (url.pathname === '/watch' && url.searchParams.has('v')) {
-                videoId = url.searchParams.get('v');
+                videoId = url.searchParams.get('v') || '';
             } else if (url.pathname.startsWith('/embed/')) {
                 videoId = url.pathname.split('/embed/')[1].split(/[/?]/)[0];
             } else if (url.pathname.startsWith('/v/')) {
                 videoId = url.pathname.split('/v/')[1].split(/[/?]/)[0];
             }
         }
+
+        // Fallback: extract from string only if it looks like a YouTube URL
         if (!videoId) {
-            const match = urlString.match(/(?:youtube\.com\/(?:watch\?v=|embed\/|v\/)|youtu\.be\/)([A-Za-z0-9_-]{11})/);
+            const match = urlString.match(/(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/|v\/)|youtu\.be\/)([A-Za-z0-9_-]{11})/i);
             if (match && match[1]) {
                 videoId = match[1];
             }
         }
-        if (videoId) {
+
+        // Ensure videoId is in expected format
+        if (videoId && /^[A-Za-z0-9_-]{11}$/.test(videoId)) {
             return `https://www.youtube.com/embed/${videoId}`;
         }
-    } catch { }
+    } catch {
+        // Invalid URL or parsing error, fall through to empty string
+    }
     return '';
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/100](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/100)

In general, the way to fix this kind of issue is to ensure that any user-controlled string passed into a DOM sink (like `src`, `href`, or inner HTML) is strictly validated or sanitized so it cannot inject unintended behavior. For URLs, this means parsing the URL, allowing only safe schemes (`https` for embeds), restricting to known-safe hostnames, and constructing the final URL from validated pieces (not passing through arbitrary query fragments or paths).

For this concrete case, the best fix is to strengthen `getYouTubeEmbedUrl` so that:
- It only accepts `http:` or `https:` schemes.
- It explicitly restricts hostnames to `youtube.com`, `www.youtube.com`, `m.youtube.com`, and `youtu.be` (and possibly `www.youtu.be`).
- It never returns attacker-controlled portions of the input URL verbatim other than the validated video ID (which is already constrained by regex).
- It fails closed (returns `''`) when parsing or validation fails.

We will implement this by updating `getYouTubeEmbedUrl` in `frontend/src/components/CreateBlogForm.jsx`. Specifically:
- After `new URL(urlString)`, we will enforce `url.protocol === 'http:' || url.protocol === 'https:'`.
- We will normalize the hostname to lowercase and compare against an explicit allowlist.
- We will ensure that any fallback regex-based extraction still only accepts valid YouTube URLs and video IDs.

No changes are necessary to the `<iframe>` usage itself, as React already treats `src` as an attribute, not HTML. Our changes remain localized to the `getYouTubeEmbedUrl` helper; existing behavior (accepting standard YouTube and youtu.be URLs and converting them to embed URLs) is preserved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Strengthen YouTube embed URL handling to mitigate DOM-based security issues by strictly validating and constraining accepted video URLs.

Bug Fixes:
- Validate YouTube URLs to only allow http/https schemes and a restricted set of YouTube hostnames before generating embed URLs.
- Ensure extracted video IDs conform to the expected format and return an empty URL on invalid or unparseable input to avoid unsafe DOM sinks.