### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/frontend/src/components/CreateBlogForm.jsx
+++ b/frontend/src/components/CreateBlogForm.jsx
@@ -97,7 +97,7 @@ const getYouTubeEmbedUrl = (urlString) => {
         let videoId = '';
         if (url.hostname === 'youtu.be') {
             videoId = url.pathname.slice(1);
-        } else if (url.hostname.includes('youtube.com')) {
+        } else if (['youtube.com', 'www.youtube.com', 'm.youtube.com'].includes(url.hostname)) {
             if (url.pathname === '/watch' && url.searchParams.has('v')) {
                 videoId = url.searchParams.get('v');
             } else if (url.pathname.startsWith('/embed/')) {


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/4](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/4)

In general, to fix this kind of problem you should not use `includes` on the hostname to infer the domain. Instead, explicitly compare the parsed hostname to a whitelist of allowed hostnames (and, if needed, normalize case and handle `www.` variants). For YouTube URLs, that means checking that `url.hostname` is exactly one of the known YouTube domains you wish to support, such as `youtube.com`, `www.youtube.com`, `m.youtube.com`, etc.

For this specific code in `frontend/src/components/CreateBlogForm.jsx`, we should change the condition:

```js
} else if (url.hostname.includes('youtube.com')) {
```

to a strict allowlist check, for example:

```js
} else if (['youtube.com', 'www.youtube.com', 'm.youtube.com'].includes(url.hostname)) {
```

This preserves existing functionality (still treats regular YouTube links as such) but avoids accepting `evil-youtube.com` or `youtube.com.evil.org`. No new imports are needed: `URL` is a standard global in modern browsers. All other logic in `getYouTubeEmbedUrl` (parsing `watch?v=`, `/embed/`, `/v/`, and the fallback regex) can remain unchanged, as the problem is only the hostname matching.

The only region that needs modification is around lines 98–107 of `CreateBlogForm.jsx`, within the `getYouTubeEmbedUrl` function. We will replace the `includes('youtube.com')` check with an allowlist and keep the rest of the function intact.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent unsafe matching of YouTube URLs by replacing a substring hostname check with an explicit allowlist of supported YouTube hostnames in the embed URL helper.