### PR TITLE
Potential fix for code scanning alert no. 101: Exception text reinterpreted as HTML

### DIFF
--- a/Backend/controllers/ai.controller.js
+++ b/Backend/controllers/ai.controller.js
@@ -6,7 +6,16 @@ export const getResult = async (req, res) => {
         const { prompt } = req.query;
         if (typeof prompt !== 'string' || prompt.trim().length === 0) return res.status(400).json({ message: 'Prompt is required' });
         const result = await ai.generateResult(prompt);
-        res.send(result);
+        // If result is a stringified object, parse it
+        let responseText;
+        try {
+            const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+            // If parsed has a 'text' property, use it; else, use the whole parsed object as string
+            responseText = parsed.text || JSON.stringify(parsed);
+        } catch (e) {
+            responseText = typeof result === 'string' ? result : JSON.stringify(result);
+        }
+        res.json({ response: responseText });
     } catch (error) {
         console.error('getResult error:', error);
         res.status(500).send({ message: 'Internal server error' });


### PR DESCRIPTION
Potential fix for [https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/101](https://github.com/Abhirajgautam28/Chatraj/security/code-scanning/101)

To fix the issue, we must ensure that any string coming from `ai.generateResult(prompt)` is not interpreted by the browser as HTML. The standard way in an Express API is to return JSON using `res.json(...)`, or at least force a non-HTML content type (e.g., `application/json` or `text/plain`) and/or escape HTML meta-characters in the string.

The minimal, non-breaking change that aligns `getResult` with `postResult` is:

- Parse the `result` from `generateResult` similarly to `postResult`, extracting a `text` property if present.
- Always send a JSON object via `res.json({ response: responseText })` instead of sending a raw string, so Express sets `Content-Type: application/json` and the browser does not treat the content as HTML.

This does not alter the semantics of what the frontend logically consumes (a `response` field with the AI text) and keeps the structure consistent with `postResult`. Concretely, in `Backend/controllers/ai.controller.js`, replace `res.send(result);` in `getResult` with logic equivalent to the `postResult` parsing block, then respond with `res.json({ response: responseText });`. No changes are needed in `ai.service.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Ensure AI GET endpoint returns JSON-safe text instead of raw content to prevent browser HTML interpretation.

Bug Fixes:
- Prevent AI getResult responses from being interpreted as HTML by always returning a JSON object with the AI text content.

Enhancements:
- Align getResult response structure with postResult by normalizing and parsing AI service output into a consistent text field.