### PR TITLE
Remove client-side XSRF cookie write; use server cookie

### DIFF
--- a/frontend/src/config/axios.js
+++ b/frontend/src/config/axios.js
@@ -88,9 +88,6 @@ export async function getCsrfToken() {
         const token = data && data.csrfToken ? data.csrfToken : null;
         if (token) {
           _cachedXsrf = token;
-          if (typeof document !== 'undefined') {
-            document.cookie = `${xsrfCookieName}=${encodeURIComponent(token)}; path=/`;
-          }
         }
         return token;
       } catch (e) {


### PR DESCRIPTION
Remove client-side XSRF cookie write; use server cookie

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate or conflicting client-side XSRF cookie writes by removing the browser cookie mutation from the CSRF token fetch flow.