### PR TITLE
CSRF: add signed-token fallback + debug endpoint; remove client cookie write

### DIFF
--- a/Backend/app.js
+++ b/Backend/app.js
@@ -11,6 +11,7 @@ import blogRoutes from './routes/blog.routes.js';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import csurf from 'csurf';
+import crypto from 'crypto';
 const allowedOrigins = [
   'https://chatraj-frontend.vercel.app',
   'https://chatraj.vercel.app',
@@ -78,30 +79,80 @@ app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
 // CSRF protection middleware using cookies
+// Configure the internal `_csrf` cookie options based on environment so its
+// flags (httpOnly/secure/sameSite) align with the public `XSRF-TOKEN` cookie
+// we set for client-side JS. We use env flags rather than per-request checks
+// when initializing csurf because csurf's cookie option is static.
+const FORCE_SECURE_COOKIES = process.env.FORCE_SECURE_COOKIES === 'true' || process.env.NODE_ENV === 'production';
+const csrfCookieOptions = {
+  httpOnly: true,
+  secure: Boolean(FORCE_SECURE_COOKIES),
+  sameSite: FORCE_SECURE_COOKIES ? 'None' : 'Lax'
+};
 const csrfProtection = csurf({
-  cookie: true,
+  cookie: csrfCookieOptions,
   ignoreMethods: ['GET', 'HEAD', 'OPTIONS']
 });
 
 // Endpoint to retrieve CSRF token for clients (e.g., SPA frontends)
 // Endpoint to retrieve CSRF token for clients (e.g., SPA frontends)
-app.get('/csrf-token', csrfProtection, (req, res) => {
+// Helper: sign/verify stateless CSRF tokens for cross-origin clients
+const CSRF_SIGNING_SECRET = process.env.CSRF_SIGNING_SECRET || process.env.SESSION_SECRET || process.env.JWT_SECRET || 'change_me_now';
+function base64urlEncode(buf) {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+function base64urlToBuffer(str) {
+  let base64 = String(str).replace(/-/g, '+').replace(/_/g, '/');
+  while (base64.length % 4) base64 += '=';
+  return Buffer.from(base64, 'base64');
+}
+function signCsrfToken() {
+  const ts = Date.now().toString();
+  const nonce = crypto.randomBytes(12).toString('hex');
+  const data = `${ts}:${nonce}`;
+  const sig = crypto.createHmac('sha256', CSRF_SIGNING_SECRET).update(data).digest();
+  return `${data}:${base64urlEncode(sig)}`;
+}
+function verifySignedCsrfToken(token) {
+  if (!token || typeof token !== 'string') return false;
+  const parts = token.split(':');
+  if (parts.length !== 3) return false;
+  const [tsStr, nonce, sig] = parts;
+  const ts = parseInt(tsStr, 10);
+  if (Number.isNaN(ts)) return false;
+  // token valid for 15 minutes
+  if (Date.now() - ts > 1000 * 60 * 15) return false;
+  const data = `${tsStr}:${nonce}`;
+  const expected = crypto.createHmac('sha256', CSRF_SIGNING_SECRET).update(data).digest();
+  let provided;
   try {
-    const token = req.csrfToken();
-    // Determine secure cookie settings from runtime request (handles proxies/CDNs)
-    const isSecureRequest = isSecureFromRequest(req);
-    const cookieOptions = {
-      httpOnly: false,
-      secure: Boolean(isSecureRequest),
-      sameSite: isSecureRequest ? 'None' : 'Lax'
-    };
-    // csurf will set its own `_csrf` cookie when configured with `cookie: true`;
-    // set a browser-friendly `XSRF-TOKEN` cookie too so axios can read it.
-    res.cookie('XSRF-TOKEN', token, cookieOptions);
-    res.status(200).json({ csrfToken: token });
-  } catch (err) {
-    res.status(500).json({ error: 'Failed to generate CSRF token' });
+    provided = base64urlToBuffer(sig);
+  } catch (e) {
+    return false;
   }
+  if (expected.length !== provided.length) return false;
+  try {
+    return crypto.timingSafeEqual(expected, provided);
+  } catch (e) {
+    return false;
+  }
+}
+
+// Debug endpoint (temporary): reports whether the incoming request contained
+// an X-XSRF-TOKEN header and whether the `_csrf` cookie was present. This
+// endpoint intentionally does NOT enforce CSRF so you can inspect what the
+// browser actually sends. Remove after debugging.
+app.all('/debug/csrf-check', (req, res) => {
+  const header = req.get('X-XSRF-TOKEN') || req.get('X-CSRF-TOKEN') || null;
+  const cookiePresent = !!(req.cookies && req.cookies._csrf);
+  return res.status(200).json({
+    headerPresent: Boolean(header),
+    headerLen: header ? String(header).length : 0,
+    cookiePresent,
+    cookieLen: cookiePresent ? String(req.cookies._csrf).length : 0,
+    origin: req.headers.origin || null,
+    host: req.headers.host || null
+  });
 });
 
 app.get('/health', (req, res) => {
@@ -118,8 +169,12 @@ app.get('/health', (req, res) => {
 // - For unsafe methods, run the csurf middleware to validate the token.
 app.use((req, res, next) => {
   const safeMethods = ['GET', 'HEAD', 'OPTIONS'];
+
+  // For safe methods, generate the csurf token and also produce a signed
+  // stateless token we can return to cross-origin clients. The signed token
+  // can be verified on unsafe requests without relying on the browser to
+  // accept/send third-party cookies.
   if (safeMethods.includes(req.method)) {
-    // run csrfProtection to generate token for safe requests
     csrfProtection(req, res, (err) => {
       if (!err) {
         try {
@@ -131,7 +186,15 @@ app.use((req, res, next) => {
               secure: Boolean(isSecureRequest),
               sameSite: isSecureRequest ? 'None' : 'Lax'
             };
+            // Prevent caching of token responses to avoid stale body vs cookie mismatches
+            res.set('Cache-Control', 'no-store, no-cache, must-revalidate');
+            res.set('Pragma', 'no-cache');
+            res.set('Surrogate-Control', 'no-store');
+            res.set('Vary', 'Origin');
+            // server-set cookie for legacy/same-origin clients
             res.cookie('XSRF-TOKEN', token, cookieOptions);
+            // attach a signed token for cross-origin clients to use in headers
+            req.signedCsrfToken = signCsrfToken();
           }
         } catch (e) {
           // ignore token generation errors for safe methods
@@ -139,9 +202,38 @@ app.use((req, res, next) => {
       }
       next(err);
     });
-  } else {
-    // validate token for unsafe methods
-    csrfProtection(req, res, next);
+    return;
+  }
+
+  // For unsafe methods, first accept a signed token in the header (stateless
+  // approach). If present and valid, bypass csurf cookie verification.
+  const header = req.get('X-XSRF-TOKEN') || req.get('X-CSRF-TOKEN');
+  if (header && verifySignedCsrfToken(header)) {
+    return next();
+  }
+
+  // Otherwise fallback to cookie-based csurf verification.
+  csrfProtection(req, res, next);
+});
+
+// Route: return CSRF token for clients. For cross-origin clients we return
+// the signed token (req.signedCsrfToken) so the client can send it in the
+// `X-XSRF-TOKEN` header; legacy clients will still receive the server-set
+// `XSRF-TOKEN` cookie.
+app.get('/csrf-token', (req, res) => {
+  try {
+    const isSecureRequest = isSecureFromRequest(req);
+    res.set('Cache-Control', 'no-store, no-cache, must-revalidate');
+    res.set('Pragma', 'no-cache');
+    res.set('Surrogate-Control', 'no-store');
+    res.set('Vary', 'Origin');
+
+    // If the middleware generated a signed token, return that; otherwise
+    // produce a fresh signed token.
+    const signed = req.signedCsrfToken || signCsrfToken();
+    return res.status(200).json({ csrfToken: signed });
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to generate CSRF token' });
   }
 });
 
@@ -157,6 +249,14 @@ app.use((err, req, res, next) => {
   // Handle CSRF errors specially
   if (err && (err.code === 'EBADCSRFTOKEN' || err.message === 'invalid csrf token')) {
     console.error('CSRF validation failed:', err.message);
+    // Helpful debug information (avoid logging full tokens in production)
+    try {
+      const headerToken = req.get('X-XSRF-TOKEN') || req.get('X-CSRF-TOKEN') || null;
+      const cookieSecret = req.cookies && req.cookies._csrf ? `[present,len=${String(req.cookies._csrf).length}]` : '[missing]';
+      console.error('CSRF debug: header present=', Boolean(headerToken), 'headerLen=', headerToken ? headerToken.length : 0, ' cookie:', cookieSecret, ' origin=', req.headers.origin, ' host=', req.headers.host);
+    } catch (e) {
+      // ignore logging errors
+    }
     return res.status(403).json({
       error: 'Invalid CSRF token',
       message: process.env.NODE_ENV === 'development' ? err.message : 'Forbidden'

--- a/Backend/scripts/verify_deploy_and_login.js
+++ b/Backend/scripts/verify_deploy_and_login.js
@@ -16,22 +16,25 @@ function arg(name, def) {
   return def;
 }
 
-const API = arg('api', process.env.BACKEND_URL || 'https://chatraj-backend.onrender.com');
+const API_RAW = arg('api', process.env.BACKEND_URL || 'https://chatraj-backend.onrender.com');
+const API = String(API_RAW).replace(/\/+$/, ''); // normalized base without trailing slash
 const EMAIL = arg('email', process.env.TEST_USER_EMAIL || 'testuser@example.com');
 const PASSWORD = arg('password', process.env.TEST_USER_PASSWORD || 'TestPass123!');
 const TIMEOUT = Number(arg('timeout', '300000')); // 5 minutes default
 const INTERVAL = Number(arg('interval', '15000'));
 
 function extractSetCookieArray(resp) {
-  // node-fetch / undici gives headers.raw()
-  if (resp.headers && typeof resp.headers.raw === 'function') {
+  // node-fetch / undici provides headers.raw()
+  if (resp && resp.headers && typeof resp.headers.raw === 'function') {
     const raw = resp.headers.raw();
     return raw && raw['set-cookie'] ? raw['set-cookie'] : [];
   }
-  const single = resp.headers && resp.headers.get ? resp.headers.get('set-cookie') : null;
-  if (!single) return [];
-  // split on cookie boundaries
-  return String(single).split(/,(?=\s*[^;]+?=)/g);
+  if (resp && resp.headers && typeof resp.headers.get === 'function') {
+    const single = resp.headers.get('set-cookie');
+    if (!single) return [];
+    return String(single).split(/,(?=\s*[^;]+?=)/g);
+  }
+  return [];
 }
 
 function buildCookieHeader(setCookieArray) {
@@ -39,34 +42,50 @@ function buildCookieHeader(setCookieArray) {
   return setCookieArray.map(c => c.split(';')[0].trim()).filter(Boolean).join('; ');
 }
 
-async function checkCsrfFlags(api) {
+async function checkCsrfFlags(apiBase) {
   try {
-    const resp = await fetch(`${api.replace(/\/$/, '')}/csrf-token`, { method: 'GET' });
-    if (!resp) return null;
+    const resp = await fetch(`${apiBase}/csrf-token`, { method: 'GET' });
+    if (!resp) return { ok: false, error: 'no response from fetch' };
+    const status = resp.status;
+    const statusText = resp.statusText || '';
     const cookies = extractSetCookieArray(resp);
+    const bodyText = await resp.text().catch(() => '');
+    let bodyJson = null;
+    try { bodyJson = JSON.parse(bodyText); } catch (e) { /* ignore */ }
+
+    if (!resp.ok) {
+      return { ok: false, status, statusText, bodyText, cookies };
+    }
+
     for (const c of cookies) {
       if (/XSRF-TOKEN=/i.test(c)) {
         const hasSameSiteNone = /samesite=none/i.test(c);
         const hasSecure = /\bsecure\b/i.test(c);
-        return { ok: true, hasSameSiteNone, hasSecure, cookies, tokenBody: await resp.text() };
+        return { ok: true, hasSameSiteNone, hasSecure, cookies, tokenBodyText: bodyText, tokenBodyJson: bodyJson };
       }
     }
-    return { ok: true, hasSameSiteNone: false, hasSecure: false, cookies: extractSetCookieArray(resp) };
+
+    return { ok: true, hasSameSiteNone: false, hasSecure: false, cookies, tokenBodyText: bodyText, tokenBodyJson: bodyJson };
   } catch (e) {
-    return null;
+    return { ok: false, error: String(e), stack: e && e.stack };
   }
 }
 
-async function attemptLogin(api, email, password) {
+async function attemptLogin(apiBase, email, password) {
   try {
-    const resp1 = await fetch(`${api.replace(/\/$/, '')}/csrf-token`, { method: 'GET' });
-    if (!resp1.ok) return { ok: false, reason: 'csrf fetch failed', status: resp1.status };
-    const body = await resp1.json().catch(() => null);
-    const token = body && body.csrfToken ? body.csrfToken : null;
+    const resp1 = await fetch(`${apiBase}/csrf-token`, { method: 'GET' });
+    if (!resp1) return { ok: false, error: 'no response from csrf fetch' };
+    const status1 = resp1.status;
+    const statusText1 = resp1.statusText || '';
     const cookies = extractSetCookieArray(resp1);
+    const bodyText = await resp1.text().catch(() => '');
+    let bodyJson = null;
+    try { bodyJson = JSON.parse(bodyText); } catch (e) { }
+    const token = (bodyJson && bodyJson.csrfToken) ? bodyJson.csrfToken : (typeof bodyText === 'string' ? (bodyText.match(/"csrfToken"\s*:\s*"([^\"]+)"/)?.[1] || '') : '');
+
     const cookieHeader = buildCookieHeader(cookies);
 
-    const r2 = await fetch(`${api.replace(/\/$/, '')}/api/users/login`, {
+    const r2 = await fetch(`${apiBase}/api/users/login`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -76,12 +95,15 @@ async function attemptLogin(api, email, password) {
       body: JSON.stringify({ email, password })
     });
 
-    const text = await r2.text();
+    const text = await r2.text().catch(() => '');
     let parsed = null;
     try { parsed = JSON.parse(text); } catch (e) { }
-    return { ok: r2.ok, status: r2.status, body: parsed || text };
+    if (!r2.ok) {
+      return { ok: false, status: r2.status, statusText: r2.statusText || '', bodyText: text, bodyJson: parsed, cookies, csrfTokenSent: token };
+    }
+    return { ok: true, status: r2.status, bodyJson: parsed || null, bodyText: text, cookies, csrfTokenSent: token };
   } catch (e) {
-    return { ok: false, error: String(e && (e.message || e)) };
+    return { ok: false, error: String(e), stack: e && e.stack };
   }
 }
 
@@ -91,20 +113,34 @@ async function run() {
   while (Date.now() < deadline) {
     process.stdout.write('.');
     const res = await checkCsrfFlags(API);
-    if (res === null) {
-      console.log('\nEndpoint unreachable; retrying in', INTERVAL / 1000, 's');
+    if (!res || res.ok === false) {
+      console.log('\n/csrf-token fetch error:', res && res.error ? res.error : `status ${res && res.status || 'unknown'}`);
     } else {
-      console.log('\n/csrf-token returned. SameSite=None:', res.hasSameSiteNone, 'Secure:', res.hasSecure);
+      console.log(`\n/csrf-token returned. SameSite=None: ${res.hasSameSiteNone} Secure: ${res.hasSecure}`);
       if (res.hasSameSiteNone && res.hasSecure) {
         console.log('Desired cookie flags present. Attempting login test...');
         const loginRes = await attemptLogin(API, EMAIL, PASSWORD);
-        console.log('Login test result:', loginRes);
-        return;
+        if (loginRes.ok) {
+          console.log('Login test succeeded:', loginRes);
+          process.exit(0);
+        } else {
+          console.log('Login test failed:', loginRes);
+          // Provide helpful debug info when login fails despite correct cookie flags
+          console.log('Debug: csrf response cookies:', res.cookies);
+          console.log('Debug: csrf response body (text):', res.tokenBodyText);
+          console.log('Debug: csrf token sent in login attempt:', loginRes.csrfTokenSent || '(none)');
+          process.exit(2);
+        }
+      } else {
+        console.log('Cookie flags not yet set. Response cookies and token body will be logged for debugging.');
+        console.log('Cookies:', res.cookies);
+        console.log('csrf response body (text):', res.tokenBodyText);
       }
     }
     await wait(INTERVAL);
   }
   console.log('\nTimeout reached; cookie flags not updated.');
+  process.exit(3);
 }
 
 run().catch(e => { console.error(e && (e.stack || e)); process.exit(1); });


### PR DESCRIPTION
CSRF: add signed-token fallback + debug endpoint; remove client cookie write

## Summary by Sourcery

Introduce a signed, stateless CSRF token flow with cookie-based fallback, plus improved CSRF debugging and verification tooling.

New Features:
- Add stateless, HMAC-signed CSRF tokens that can be used via headers as an alternative to cookie-based CSRF protection for cross-origin clients.
- Expose a debug endpoint to inspect incoming CSRF headers and cookies without enforcing CSRF, aiding browser and CDN troubleshooting.

Bug Fixes:
- Align internal csurf cookie flags with the public XSRF-TOKEN cookie based on environment to avoid mismatched cookie attributes in different deployments.
- Normalize backend base URLs in the verification script to prevent issues caused by trailing slashes in API configuration.'],'enhancements':[

Chores:
- Enhance the deployment verification script to capture and log detailed CSRF, cookie, and login responses, including bodies and errors, and to use explicit exit codes for success and failure paths.