### PR TITLE
Ops: remove CSRF_DEBUG, restrict signing-secret fallback to dev-only;add GH Actions workflow + script to set Render env var

### DIFF
--- a/.github/scripts/set_render_env.js
+++ b/.github/scripts/set_render_env.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Script: set_render_env.js
+// Purpose: create or update an environment variable for a Render service
+// Usage (from GH Action): provide RENDER_API_KEY, SERVICE_ID, ENV_KEY, ENV_VALUE
+
+(async () => {
+  try {
+    const apiKey = process.env.RENDER_API_KEY;
+    const serviceId = process.env.SERVICE_ID;
+    const key = process.env.ENV_KEY || 'CSRF_SIGNING_SECRET';
+    const value = process.env.ENV_VALUE;
+
+    if (!apiKey || !serviceId || !value) {
+      console.error('Missing required env vars. Set RENDER_API_KEY, SERVICE_ID, and ENV_VALUE.');
+      process.exit(1);
+    }
+
+    const headers = { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' };
+    const listUrl = `https://api.render.com/v1/services/${serviceId}/env-vars`;
+
+    const listResp = await fetch(listUrl, { headers });
+    if (!listResp.ok) {
+      const body = await listResp.text().catch(() => '<no body>');
+      console.error('Failed to list env vars:', listResp.status, body);
+      process.exit(1);
+    }
+
+    const list = await listResp.json();
+    const existing = Array.isArray(list) ? list.find(e => e.key === key) : null;
+
+    if (existing && existing.id) {
+      const updateUrl = `https://api.render.com/v1/services/${serviceId}/env-vars/${existing.id}`;
+      const updateResp = await fetch(updateUrl, { method: 'PATCH', headers, body: JSON.stringify({ value, secure: true }) });
+      if (!updateResp.ok) {
+        const body = await updateResp.text().catch(() => '<no body>');
+        console.error('Failed to update env var:', updateResp.status, body);
+        process.exit(1);
+      }
+      console.log('Updated env var', key);
+      process.exit(0);
+    }
+
+    // Create
+    const createResp = await fetch(listUrl, { method: 'POST', headers, body: JSON.stringify({ key, value, secure: true }) });
+    if (!createResp.ok) {
+      const body = await createResp.text().catch(() => '<no body>');
+      console.error('Failed to create env var:', createResp.status, body);
+      process.exit(1);
+    }
+    console.log('Created env var', key);
+    process.exit(0);
+  } catch (err) {
+    console.error('Error setting env var:', err && (err.stack || err.message || String(err)));
+    process.exit(1);
+  }
+})();

--- a/.github/workflows/set-deploy-env.yml
+++ b/.github/workflows/set-deploy-env.yml
@@ -1,0 +1,46 @@
+name: Set deploy environment variable
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Target platform (render)'
+        required: true
+        default: 'render'
+      render_service_id:
+        description: 'Render service id (srv-...)'
+        required: false
+
+jobs:
+  set-render-env:
+    if: ${{ github.event.inputs.platform == 'render' }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Set Render env var (CSRF_SIGNING_SECRET)
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          SERVICE_ID: ${{ github.event.inputs.render_service_id }}
+          ENV_KEY: CSRF_SIGNING_SECRET
+          ENV_VALUE: ${{ secrets.CSRF_SIGNING_SECRET }}
+        run: |
+          if [ -z "${RENDER_API_KEY}" ]; then
+            echo "RENDER_API_KEY secret is missing. Add it to repository secrets as RENDER_API_KEY.";
+            exit 1;
+          fi
+          if [ -z "${SERVICE_ID}" ]; then
+            echo "render_service_id input is required. Provide it when dispatching the workflow.";
+            exit 1;
+          fi
+          node .github/scripts/set_render_env.js
+
+  # Vercel support: add a separate job here if you use Vercel.
+  # Example: use Vercel CLI or API; keep tokens in secrets and do not echo values.

--- a/Backend/app.js
+++ b/Backend/app.js
@@ -96,19 +96,20 @@ const csrfProtection = csurf({
 
 // Endpoint to retrieve CSRF token for clients (e.g., SPA frontends)
 // Endpoint to retrieve CSRF token for clients (e.g., SPA frontends)
-// Debug mode for CSRF internals: enabled in development or when explicitly set
-const CSRF_DEBUG = process.env.CSRF_DEBUG === 'true' || process.env.NODE_ENV === 'development';
+// Note: CSRF debug flag removed. Debug logging is gated by
+// `NODE_ENV === 'development'` directly to avoid unused flags.
 
 // Helper: sign/verify stateless CSRF tokens for cross-origin clients
 const CSRF_SIGNING_SECRET = (() => {
   const v = process.env.CSRF_SIGNING_SECRET || process.env.SESSION_SECRET || process.env.JWT_SECRET;
   if (!v) {
-    if (process.env.NODE_ENV === 'production') {
-      throw new Error('CSRF_SIGNING_SECRET (or SESSION_SECRET/JWT_SECRET) must be set in production');
+    // Only permit the insecure fallback in explicit development mode.
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('Warning: CSRF_SIGNING_SECRET not set; falling back to insecure default for development only. Set CSRF_SIGNING_SECRET in non-development environments.');
+      return 'change_me_now';
     }
-    // Development fallback (insecure) but log prominently so maintainers change it
-    console.warn('Warning: CSRF_SIGNING_SECRET not set; falling back to insecure default for development only. Set CSRF_SIGNING_SECRET in production.');
-    return 'change_me_now';
+    // For staging/production/other environments, require an explicit secret.
+    throw new Error('CSRF_SIGNING_SECRET (or SESSION_SECRET/JWT_SECRET) must be set in non-development environments');
   }
   return v;
 })();
@@ -253,7 +254,8 @@ app.use((err, req, res, next) => {
     console.error('CSRF validation failed:', err.message);
     // Helpful debug information (avoid logging full tokens in production)
     try {
-      if (CSRF_DEBUG) {
+      // Development-only CSRF debug logging — avoid exposing token details
+      if (process.env.NODE_ENV === 'development') {
         const headerToken = req.get('X-XSRF-TOKEN') || req.get('X-CSRF-TOKEN') || null;
         const cookieSecret = req.cookies && req.cookies._csrf ? `[present,len=${String(req.cookies._csrf).length}]` : '[missing]';
         console.error('CSRF debug: header present=', Boolean(headerToken), 'headerLen=', headerToken ? headerToken.length : 0, ' cookie:', cookieSecret, ' origin=', req.headers.origin, ' host=', req.headers.host);


### PR DESCRIPTION
Ops: remove CSRF_DEBUG, restrict signing-secret fallback to dev-only;add GH Actions workflow + script to set Render env var

## Summary by Sourcery

Tighten CSRF configuration for non-development environments and add automation to manage deployment environment variables on Render via GitHub Actions.

New Features:
- Add a GitHub Actions workflow to set a CSRF_SIGNING_SECRET environment variable on a Render service.
- Introduce a Node.js helper script to create or update environment variables on Render via its API.

Enhancements:
- Restrict the insecure fallback CSRF signing secret to development only and require an explicit secret in other environments.
- Remove the unused CSRF_DEBUG flag and gate CSRF debug logging directly on development mode.

CI:
- Add a manually triggered CI workflow to configure Render environment variables using repository secrets.

Deployment:
- Automate propagation of the CSRF signing secret to Render deployment environments via the new workflow and script.