### PR TITLE
Fix(Vercel): parse env list shape and include type; constrain workflows to CSRF_SIGNING_SECRET to avoid mismatched keys

### DIFF
--- a/.github/scripts/set_vercel_env.js
+++ b/.github/scripts/set_vercel_env.js
@@ -28,11 +28,21 @@
     }
 
     const list = await listResp.json();
-    const existing = Array.isArray(list) ? list.find(e => e.key === key) : null;
+    // Vercel's response may wrap envs in an object (e.g., { envs: [...] }).
+    let envList = [];
+    if (Array.isArray(list)) envList = list;
+    else if (Array.isArray(list.envs)) envList = list.envs;
+    else if (Array.isArray(list.envs?.envs)) envList = list.envs.envs; // defensive
+    else envList = [];
+    const existing = envList.find(e => e.key === key) || null;
 
     if (existing && existing.id) {
       const updateUrl = `https://api.vercel.com/v9/projects/${projectId}/env/${existing.id}`;
-      const updateResp = await fetch(updateUrl, { method: 'PATCH', headers, body: JSON.stringify({ value, target: [target] }) });
+      const updatePayload = { value, target: [target] };
+      // preserve type if present, otherwise treat as encrypted
+      if (existing.type) updatePayload.type = existing.type;
+      else updatePayload.type = 'encrypted';
+      const updateResp = await fetch(updateUrl, { method: 'PATCH', headers, body: JSON.stringify(updatePayload) });
       if (!updateResp.ok) {
         const body = await updateResp.text().catch(() => '<no body>');
         console.error('Failed to update Vercel env var:', updateResp.status, body);
@@ -43,7 +53,9 @@
     }
 
     // Create
-    const createResp = await fetch(listUrl, { method: 'POST', headers, body: JSON.stringify({ key, value, target: [target] }) });
+    // Create: Vercel expects a `type` (e.g. 'encrypted') for secret values.
+    const createPayload = { key, value, target: [target], type: 'encrypted' };
+    const createResp = await fetch(listUrl, { method: 'POST', headers, body: JSON.stringify(createPayload) });
     if (!createResp.ok) {
       const body = await createResp.text().catch(() => '<no body>');
       console.error('Failed to create Vercel env var:', createResp.status, body);

--- a/.github/workflows/set-deploy-env-vercel.yml
+++ b/.github/workflows/set-deploy-env-vercel.yml
@@ -6,9 +6,6 @@ on:
       vercel_project_id:
         description: 'Vercel project id (proj_...)'
         required: true
-      env_key:
-        description: 'Environment variable key to set (e.g., CSRF_SIGNING_SECRET)'
-        required: true
       target:
         description: 'Vercel target environment (production|preview|development)'
         required: false
@@ -31,7 +28,7 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ github.event.inputs.vercel_project_id }}
-          ENV_KEY: ${{ github.event.inputs.env_key }}
+          ENV_KEY: CSRF_SIGNING_SECRET
           ENV_VALUE: ${{ secrets.CSRF_SIGNING_SECRET }}
           VERCEL_TARGET: ${{ github.event.inputs.target }}
         run: |

--- a/.github/workflows/set-deploy-env.yml
+++ b/.github/workflows/set-deploy-env.yml
@@ -7,9 +7,6 @@ on:
         description: 'Target platform (render)'
         required: true
         default: 'render'
-      env_key:
-        description: 'Environment variable key to set (e.g., CSRF_SIGNING_SECRET)'
-        required: true
       render_service_id:
         description: 'Render service id (srv-...)'
         required: false
@@ -32,7 +29,7 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           SERVICE_ID: ${{ github.event.inputs.render_service_id }}
-          ENV_KEY: ${{ github.event.inputs.env_key }}
+          ENV_KEY: CSRF_SIGNING_SECRET
           ENV_VALUE: ${{ secrets.CSRF_SIGNING_SECRET }}
         run: |
           if [ -z "${RENDER_API_KEY}" ]; then


### PR DESCRIPTION
Fix(Vercel): parse env list shape and include type; constrain workflows to CSRF_SIGNING_SECRET to avoid mismatched keys

## Summary by Sourcery

Improve handling of Vercel environment variables in deployment scripts and lock deployment workflows to a specific CSRF signing secret.

Enhancements:
- Handle multiple possible response shapes from the Vercel env list API when locating an existing environment variable.
- Preserve or explicitly set the environment variable type when creating or updating Vercel env values to ensure they are treated as encrypted secrets.

CI:
- Update Vercel and Render deployment workflows to always set the CSRF_SIGNING_SECRET key explicitly instead of accepting a configurable env_key input.