### PR TITLE
Fix: make workflow comments tool-agnostic

### DIFF
--- a/.github/workflows/set-deploy-env-vercel.yml
+++ b/.github/workflows/set-deploy-env-vercel.yml
@@ -1,4 +1,4 @@
-## Normalized by assistant to ensure valid workflow_dispatch handling
+## Normalized to ensure valid workflow_dispatch handling
 name: Set Vercel deploy environment variable
 
 on:

--- a/.github/workflows/set-deploy-env.yml
+++ b/.github/workflows/set-deploy-env.yml
@@ -1,4 +1,4 @@
-## Normalized by assistant to ensure valid workflow_dispatch handling
+## Normalized to ensure valid workflow_dispatch handling
 name: Set deploy environment variable
 
 on:


### PR DESCRIPTION
Remove references to 'assistant' from workflow comments so they are tool-agnostic (address code review feedback).

## Summary by Sourcery

Chores:
- Standardize GitHub Actions workflow normalization comments to avoid referencing specific tools or assistants.