### PR TITLE
chore: add PR-trigger ops workflow (pull_request_target)

### DIFF
--- a/.github/workflows/ops-set-deploy-env-pr.yml
+++ b/.github/workflows/ops-set-deploy-env-pr.yml
@@ -1,0 +1,52 @@
+## Ops PR workflow: run set-deploy-env from an ops branch via `pull_request_target`
+name: Ops: Set deploy env via PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  set-deploy-env:
+    # Only run for PRs from the ops branch and initiated by the repo owner
+    if: "github.event.pull_request.head.ref == 'ops/set-deploy-env' && github.actor == 'Abhirajgautam28' && github.base_ref == 'main'"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base (main)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Set Render env var (CSRF_SIGNING_SECRET)
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          SERVICE_ID: srv-d0jm2j56ubrc73ajtedg
+          ENV_KEY: CSRF_SIGNING_SECRET
+          ENV_VALUE: ${{ secrets.CSRF_SIGNING_SECRET }}
+        run: |
+          if [ -z "${RENDER_API_KEY}" ]; then
+            echo "RENDER_API_KEY secret is missing. Aborting.";
+            exit 1;
+          fi
+          node .github/scripts/set_render_env.js
+
+      - name: Set Vercel env var (CSRF_SIGNING_SECRET)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: prj_obPaSXFtnFtEJrV0udUw8Alg8jKw
+          ENV_KEY: CSRF_SIGNING_SECRET
+          ENV_VALUE: ${{ secrets.CSRF_SIGNING_SECRET }}
+          VERCEL_TARGET: production
+        run: |
+          if [ -z "${VERCEL_TOKEN}" ]; then
+            echo "VERCEL_TOKEN secret is missing. Aborting.";
+            exit 1;
+          fi
+          node .github/scripts/set_vercel_env.js


### PR DESCRIPTION
Adds a safe pull_request_target workflow to run the env-set scripts when a PR is opened from the ops branch. This lets the repo owner trigger environment updates without relying on manual dispatch.

## Summary by Sourcery

Add a GitHub Actions workflow to safely run environment setup scripts from ops pull requests.

Build:
- Introduce ops-set-deploy-env-pr workflow triggered by pull_request_target for ops/set-deploy-env branch PRs targeting main.

Deployment:
- Automate updating CSRF_SIGNING_SECRET in Render and Vercel production environments via a restricted PR-based workflow.