### PR TITLE
fix(csrf): avoid client cookie overwrite and use getCsrfToken() for login

### DIFF
--- a/frontend/src/config/axios.js
+++ b/frontend/src/config/axios.js
@@ -88,9 +88,12 @@ export async function getCsrfToken() {
         const token = data && data.csrfToken ? data.csrfToken : null;
         if (token) {
           _cachedXsrf = token;
-          if (typeof document !== 'undefined') {
-            document.cookie = `${xsrfCookieName}=${encodeURIComponent(token)}; path=/`;
-          }
+          // Do NOT write the XSRF cookie from client-side JS. Writing here
+          // can overwrite the server-set cookie and strip Secure/SameSite
+          // attributes, preventing the browser from sending the server's
+          // httpOnly `_csrf` cookie on cross-site requests. Rely on the
+          // server to set cookie attributes correctly and use the returned
+          // token value directly for headers.
         }
         return token;
       } catch (e) {

--- a/frontend/src/screens/Login.jsx
+++ b/frontend/src/screens/Login.jsx
@@ -79,47 +79,47 @@ const Login = () => {
             setShowRecaptcha(true);
         }
     }
-    function handleRecaptcha(token) {
+    async function handleRecaptcha(token) {
         setLoginError('');
         // If recaptcha is disabled, skip token check
         if (isRecaptchaDisabled || token) {
-            // Ensure XSRF header is explicitly attached in case automatic
-            // axios xsrf handling does not run (cross-origin dev setup).
+            // Use the centralized getCsrfToken helper to obtain the
+            // token returned by the server (avoids reading/writing
+            // document.cookie which can overwrite server-set attributes).
             let xsrfHeader = {};
             try {
-                const match = document.cookie.match(new RegExp('(^|; )XSRF-TOKEN=([^;]*)'));
-                if (match) xsrfHeader['X-XSRF-TOKEN'] = decodeURIComponent(match[2]);
+                const csrf = await getCsrfToken();
+                if (csrf) xsrfHeader['X-XSRF-TOKEN'] = csrf;
             } catch (e) {
-                // ignore
+                // ignore and let request proceed; server will reject if required
             }
 
-            axios.post('/api/users/login', { email, password, recaptchaToken: token }, { headers: xsrfHeader, withCredentials: true })
-                .then((res) => {
-                    localStorage.setItem('token', res.data.token);
-                    setUser(res.data.user);
+            try {
+                const res = await axios.post('/api/users/login', { email, password, recaptchaToken: token }, { headers: xsrfHeader, withCredentials: true });
+                localStorage.setItem('token', res.data.token);
+                setUser(res.data.user);
 
-                    const fromTryChatRaj = localStorage.getItem('fromTryChatRaj');
-                    if (fromTryChatRaj === 'true') {
-                        localStorage.removeItem('fromTryChatRaj');
-                        navigate('/welcome-chatraj', { replace: true });
-                    } else if (location.state && location.state.from) {
-                        // If user came from a blog tile click and wants to go to main blog page
-                        if (localStorage.getItem('redirectToBlogPage') === 'true' && location.state.from === 'homepage-blog-tile') {
-                            localStorage.removeItem('redirectToBlogPage');
-                            navigate('/blogs', { replace: true });
-                        } else {
-                            navigate(location.state.from, { replace: true });
-                        }
+                const fromTryChatRaj = localStorage.getItem('fromTryChatRaj');
+                if (fromTryChatRaj === 'true') {
+                    localStorage.removeItem('fromTryChatRaj');
+                    navigate('/welcome-chatraj', { replace: true });
+                } else if (location.state && location.state.from) {
+                    // If user came from a blog tile click and wants to go to main blog page
+                    if (localStorage.getItem('redirectToBlogPage') === 'true' && location.state.from === 'homepage-blog-tile') {
+                        localStorage.removeItem('redirectToBlogPage');
+                        navigate('/blogs', { replace: true });
                     } else {
-                        navigate('/categories', { replace: true });
+                        navigate(location.state.from, { replace: true });
                     }
-                    setShowRecaptcha(false);
-                })
-                .catch((error) => {
-                    console.error('Login error:', error.response?.data || error);
-                    setLoginError('Login failed. Please check your credentials.');
-                    setShowRecaptcha(false);
-                });
+                } else {
+                    navigate('/categories', { replace: true });
+                }
+                setShowRecaptcha(false);
+            } catch (error) {
+                console.error('Login error:', error.response?.data || error);
+                setLoginError('Login failed. Please check your credentials.');
+                setShowRecaptcha(false);
+            }
         } else {
             setLoginError('reCAPTCHA verification failed. Please try again.');
         }


### PR DESCRIPTION
fix(csrf): avoid client cookie overwrite and use getCsrfToken() for login

## Summary by Sourcery

Use centralized CSRF token helper for login to avoid client-side cookie overwrites and rely on server-managed cookie attributes.

Bug Fixes:
- Prevent client-side overwriting of server-set CSRF cookies during token retrieval for login requests.

Enhancements:
- Refactor login recaptcha handler to use async/await while integrating the shared CSRF token helper.