### PR TITLE
fix: merge CSRF fallback and frontend fixes

### DIFF
--- a/Backend/app.js
+++ b/Backend/app.js
@@ -11,6 +11,49 @@ import blogRoutes from './routes/blog.routes.js';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import csurf from 'csurf';
+import crypto from 'crypto';
+
+// CSRF signing secret used for stateless signed tokens (fallback for cross-origin clients)
+const CSRF_SIGNING_SECRET = (() => {
+  if (process.env.CSRF_SIGNING_SECRET) return process.env.CSRF_SIGNING_SECRET;
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn('CSRF_SIGNING_SECRET not set — using development fallback (insecure)');
+    return 'dev-csrf-signing-secret';
+  }
+  throw new Error('CSRF_SIGNING_SECRET must be set in production');
+})();
+
+function signRawToken(raw) {
+  return `${raw}.${crypto.createHmac('sha256', CSRF_SIGNING_SECRET).update(raw).digest('base64url')}`;
+}
+
+function verifySignedCsrfToken(signed) {
+  try {
+    if (!signed || typeof signed !== 'string') return false;
+    const parts = signed.split('.');
+    if (parts.length !== 2) return false;
+    const [raw, sig] = parts;
+    const expected = crypto.createHmac('sha256', CSRF_SIGNING_SECRET).update(raw).digest('base64url');
+    const a = Buffer.from(sig);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length) return false;
+    if (!crypto.timingSafeEqual(a, b)) return false;
+    const idx = raw.indexOf(':');
+    if (idx === -1) return false;
+    const ts = Number(raw.slice(0, idx));
+    if (Number.isNaN(ts)) return false;
+    // token expiry: 1 hour
+    if (Date.now() - ts > 1000 * 60 * 60) return false;
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function createSignedCsrf() {
+  const raw = `${Date.now()}:${crypto.randomBytes(12).toString('base64url')}`;
+  return signRawToken(raw);
+}
 const allowedOrigins = [
   'https://chatraj-frontend.vercel.app',
   'https://chatraj.vercel.app',
@@ -98,7 +141,12 @@ app.get('/csrf-token', csrfProtection, (req, res) => {
     // csurf will set its own `_csrf` cookie when configured with `cookie: true`;
     // set a browser-friendly `XSRF-TOKEN` cookie too so axios can read it.
     res.cookie('XSRF-TOKEN', token, cookieOptions);
-    res.status(200).json({ csrfToken: token });
+    // Also provide a signed, stateless CSRF token in the response body so
+    // clients that cannot reliably use cookies (third-party cookie blocks,
+    // strict privacy modes, etc.) can use this token as a fallback. The
+    // signed token is time-limited and verified server-side.
+    const signed = createSignedCsrf();
+    res.status(200).json({ csrfToken: token, signedCsrf: signed });
   } catch (err) {
     res.status(500).json({ error: 'Failed to generate CSRF token' });
   }
@@ -140,7 +188,20 @@ app.use((req, res, next) => {
       next(err);
     });
   } else {
-    // validate token for unsafe methods
+    // For unsafe methods, allow either the standard csurf validation or a
+    // server-signed stateless CSRF token provided by trusted clients. This
+    // helps support cross-origin frontends (e.g., Vercel) that cannot
+    // persist third-party cookies in some browsers.
+    try {
+      const signedHeader = req.headers['x-csrf-signed'] || req.headers['x-csrf-signed-token'];
+      if (signedHeader && verifySignedCsrfToken(signedHeader)) {
+        // Signed token valid — bypass csurf validation for this request.
+        return next();
+      }
+    } catch (e) {
+      // ignore and fall through to regular csurf validation
+    }
+    // validate token for unsafe methods using csurf
     csrfProtection(req, res, next);
   }
 });

--- a/frontend/src/config/axios.js
+++ b/frontend/src/config/axios.js
@@ -90,9 +90,10 @@ export async function getCsrfToken() {
         const token = data && data.csrfToken ? data.csrfToken : null;
         if (token) {
           _cachedXsrf = token;
-          if (typeof document !== 'undefined') {
-            document.cookie = `${xsrfCookieName}=${encodeURIComponent(token)}; path=/`;
-          }
+          // Do NOT write the XSRF cookie from client-side JS. Writing here
+          // can overwrite server-set cookie attributes (Secure/SameSite) and
+          // break cross-origin cookie behavior. Rely on server-set cookies
+          // and use the returned token directly for request headers.
         }
         return token;
       } catch (e) {

--- a/frontend/src/config/axios.js
+++ b/frontend/src/config/axios.js
@@ -30,6 +30,7 @@ axiosInstance.defaults.xsrfHeaderName = 'X-XSRF-TOKEN';
 // Simple in-memory cache and single in-flight fetch memoization for CSRF token
 let _cachedXsrf = null;
 let _xsrfFetchPromise = null;
+let _cachedSignedXsrf = null;
 
 axiosInstance.interceptors.request.use(
   async config => {
@@ -45,6 +46,10 @@ axiosInstance.interceptors.request.use(
       const xsrfHeaderName = axiosInstance.defaults.xsrfHeaderName || 'X-XSRF-TOKEN';
       const xsrfValue = await getCsrfToken();
       if (xsrfValue) config.headers[xsrfHeaderName] = xsrfValue;
+      // Include signed stateless CSRF token when available (fallback for
+      // browsers that block third-party cookies). The backend will accept
+      // this header as an alternative to cookie-based csurf validation.
+      if (_cachedSignedXsrf) config.headers['X-CSRF-SIGNED'] = _cachedSignedXsrf;
     } catch (e) {
       // ignore in non-browser environments or when fetch fails
     }
@@ -88,13 +93,9 @@ export async function getCsrfToken() {
         if (!resp.ok) return null;
         const data = await resp.json();
         const token = data && data.csrfToken ? data.csrfToken : null;
-        if (token) {
-          _cachedXsrf = token;
-          // Do NOT write the XSRF cookie from client-side JS. Writing here
-          // can overwrite server-set cookie attributes (Secure/SameSite) and
-          // break cross-origin cookie behavior. Rely on server-set cookies
-          // and use the returned token directly for request headers.
-        }
+        const signed = data && data.signedCsrf ? data.signedCsrf : null;
+        if (token) _cachedXsrf = token;
+        if (signed) _cachedSignedXsrf = signed;
         return token;
       } catch (e) {
         return null;

--- a/frontend/src/screens/Login.jsx
+++ b/frontend/src/screens/Login.jsx
@@ -79,47 +79,40 @@ const Login = () => {
             setShowRecaptcha(true);
         }
     }
-    function handleRecaptcha(token) {
+    async function handleRecaptcha(token) {
         setLoginError('');
         // If recaptcha is disabled, skip token check
         if (isRecaptchaDisabled || token) {
-            // Ensure XSRF header is explicitly attached in case automatic
-            // axios xsrf handling does not run (cross-origin dev setup).
-            let xsrfHeader = {};
+            // Ensure the CSRF token(s) are fetched so the axios interceptor
+            // can attach the appropriate headers (cookie token and/or
+            // signed stateless token) before making the request.
             try {
-                const match = document.cookie.match(new RegExp('(^|; )XSRF-TOKEN=([^;]*)'));
-                if (match) xsrfHeader['X-XSRF-TOKEN'] = decodeURIComponent(match[2]);
-            } catch (e) {
-                // ignore
-            }
+                await getCsrfToken();
+                const res = await axios.post('/api/users/login', { email, password, recaptchaToken: token });
+                localStorage.setItem('token', res.data.token);
+                setUser(res.data.user);
 
-            axios.post('/api/users/login', { email, password, recaptchaToken: token }, { headers: xsrfHeader, withCredentials: true })
-                .then((res) => {
-                    localStorage.setItem('token', res.data.token);
-                    setUser(res.data.user);
-
-                    const fromTryChatRaj = localStorage.getItem('fromTryChatRaj');
-                    if (fromTryChatRaj === 'true') {
-                        localStorage.removeItem('fromTryChatRaj');
-                        navigate('/welcome-chatraj', { replace: true });
-                    } else if (location.state && location.state.from) {
-                        // If user came from a blog tile click and wants to go to main blog page
-                        if (localStorage.getItem('redirectToBlogPage') === 'true' && location.state.from === 'homepage-blog-tile') {
-                            localStorage.removeItem('redirectToBlogPage');
-                            navigate('/blogs', { replace: true });
-                        } else {
-                            navigate(location.state.from, { replace: true });
-                        }
+                const fromTryChatRaj = localStorage.getItem('fromTryChatRaj');
+                if (fromTryChatRaj === 'true') {
+                    localStorage.removeItem('fromTryChatRaj');
+                    navigate('/welcome-chatraj', { replace: true });
+                } else if (location.state && location.state.from) {
+                    // If user came from a blog tile click and wants to go to main blog page
+                    if (localStorage.getItem('redirectToBlogPage') === 'true' && location.state.from === 'homepage-blog-tile') {
+                        localStorage.removeItem('redirectToBlogPage');
+                        navigate('/blogs', { replace: true });
                     } else {
-                        navigate('/categories', { replace: true });
+                        navigate(location.state.from, { replace: true });
                     }
-                    setShowRecaptcha(false);
-                })
-                .catch((error) => {
-                    console.error('Login error:', error.response?.data || error);
-                    setLoginError('Login failed. Please check your credentials.');
-                    setShowRecaptcha(false);
-                });
+                } else {
+                    navigate('/categories', { replace: true });
+                }
+                setShowRecaptcha(false);
+            } catch (error) {
+                console.error('Login error:', error.response?.data || error);
+                setLoginError('Login failed. Please check your credentials.');
+                setShowRecaptcha(false);
+            }
         } else {
             setLoginError('reCAPTCHA verification failed. Please try again.');
         }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -36,21 +36,27 @@ export default defineConfig({
       protocol: 'ws',
       clientPort: 5173
     },
-    // Proxy API and CSRF token requests to the backend in development so
-    // the browser sees a same-origin API and cookies are preserved.
-    proxy: {
-      '/api': {
-        target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8080',
-        changeOrigin: true,
-        secure: false,
-        ws: true
-      },
-      '/csrf-token': {
-        target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8080',
-        changeOrigin: true,
-        secure: false,
-        ws: true
+    // Proxy configuration: route API and CSRF calls to the local backend
+    // so the browser perceives same-origin requests and cookies are sent.
+    // Keep options DRY and allow overriding the proxy target via env.
+    proxy: (() => {
+      const proxyTarget = process.env.VITE_API_PROXY_TARGET || 'http://localhost:8080';
+      const baseOptions = { target: proxyTarget, changeOrigin: true, secure: false };
+      return {
+        '/api': { ...baseOptions, ws: true },
+        // CSRF token endpoint does not require WebSocket support; keep ws: false
+        // to reduce the surface area and express intent clearly.
+        '/csrf-token': { ...baseOptions, ws: false }
+      };
+    })(),
+    // Optionally set cross-origin isolation headers used by certain APIs
+    // (SharedArrayBuffer, performance.measureUserAgentSpecificMemory, etc.).
+    // Enable in development by setting `VITE_ENABLE_COOP_COEP=true` if needed.
+    ...(process.env.VITE_ENABLE_COOP_COEP === 'true' ? {
+      headers: {
+        'Cross-Origin-Embedder-Policy': 'require-corp',
+        'Cross-Origin-Opener-Policy': 'same-origin'
       }
-    }
+    } : {}),
   }
 })


### PR DESCRIPTION
Resolved merge conflicts; updated axios CSRF handling and Login component to use signed CSRF fallback.

## Summary by Sourcery

Introduce a signed, stateless CSRF fallback flow and wire frontend and backend to support it alongside existing cookie-based CSRF protection.

New Features:
- Add backend support for issuing and validating signed, time-limited CSRF tokens as a fallback to cookie-based protection.
- Extend the CSRF endpoint to return both cookie-based and signed CSRF tokens for clients with differing capabilities.

Bug Fixes:
- Ensure login and other axios calls work reliably in environments where third-party cookies are blocked by leveraging the signed CSRF fallback.

Enhancements:
- Update axios configuration and interceptors to automatically attach cookie and/or signed CSRF tokens on unsafe requests.
- Refine the login flow to rely on the centralized CSRF helper and axios interceptors instead of manually assembling CSRF headers.
- Simplify and DRY up Vite dev server proxy settings and add optional COOP/COEP headers for advanced browser APIs.