### PR TITLE
fix(recaptcha): disable on localhost; fix API paths; reduce registration 429

### DIFF
--- a/Backend/routes/user.routes.js
+++ b/Backend/routes/user.routes.js
@@ -17,6 +17,17 @@ const usersLimiter = rateLimit({
   max: 100, // limit each IP to 100 user list requests per windowMs
 });
 
+// Slightly higher limit for registration to reduce false positives
+// during legitimate user signups (e.g., when users retry due to client-side
+// behavior). Keep `sensitiveLimiter` unchanged for login and other sensitive
+// endpoints to preserve stricter throttling there.
+const registrationLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 12,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 // Send OTP for password reset (used in Login.jsx)
 router.post('/send-otp', sensitiveLimiter, userController.sendOtpController);
 
@@ -26,7 +37,7 @@ router.post('/register',
   body('email').isEmail().withMessage('Email must be a valid email address'),
   body('password').isLength({ min: 8 }).withMessage('Password must be at least 8 characters long'),
   body('googleApiKey').isLength({ min: 10 }).withMessage('Google API Key is required'),
-  sensitiveLimiter,
+  registrationLimiter,
   userController.createUserController
 );
 

--- a/frontend/src/screens/Project.jsx
+++ b/frontend/src/screens/Project.jsx
@@ -364,7 +364,7 @@ const Project = () => {
 
   function addCollaborators() {
     axios
-      .put("/projects/add-user", {
+      .put("/api/projects/add-user", {
         projectId: location.state.project._id,
         users: Array.from(selectedUserId)
       })
@@ -443,7 +443,7 @@ const Project = () => {
       setFileTree(res.data.project.fileTree || {})
     })
     axios
-      .get("/users/all")
+      .get("/api/users/all")
       .then((res) => {
         setUsers(res.data.users)
       })

--- a/frontend/src/screens/Register.jsx
+++ b/frontend/src/screens/Register.jsx
@@ -22,6 +22,9 @@ const Register = () => {
 
     const [errorMsg, setErrorMsg] = useState('');
     const [showRecaptcha, setShowRecaptcha] = useState(false);
+    // disable reCAPTCHA locally (sitekey often restricted to deployed domain)
+    const isLocalhost = typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
+    const recaptchaEnabled = import.meta.env.VITE_DISABLE_RECAPTCHA !== 'true' && !isLocalhost;
     // ...removed unused recaptchaToken
     const containerRef = useRef(null);
 
@@ -63,28 +66,42 @@ const Register = () => {
             setErrorMsg('Google API Key must be at least 10 characters long.');
             return;
         }
-        setShowRecaptcha(true);
+        // If recaptcha is enabled (deployed site), show widget. For local/dev,
+        // skip reCAPTCHA and proceed directly to registration to avoid
+        // "Localhost not in supported domains" errors.
+        if (recaptchaEnabled) {
+            setShowRecaptcha(true);
+        } else {
+            doRegister();
+        }
     }
 
     function handleRecaptcha(token) {
         if (token) {
             // Proceed with registration after reCAPTCHA
-            axios.post('/api/users/register', { firstName, lastName, email, password, googleApiKey })
-                .then((res) => {
-                    setUserId(res.data.userId);
-                    setShowOtpModal(true);
-                    setShowRecaptcha(false);
-                })
-                .catch((error) => {
-                    if (error.response?.data?.errors) {
-                        setErrorMsg(error.response.data.errors.map(e => e.msg).join(' '));
-                    } else {
-                        setErrorMsg('Registration failed. Please try again.');
-                    }
-                    setShowRecaptcha(false);
-                });
+            doRegister();
         }
+        }
+
+    // Extracted registration logic so we can call it directly when
+    // reCAPTCHA is intentionally disabled (local dev).
+    function doRegister() {
+        axios.post('/api/users/register', { firstName, lastName, email, password, googleApiKey })
+            .then((res) => {
+                setUserId(res.data.userId);
+                setShowOtpModal(true);
+                setShowRecaptcha(false);
+            })
+            .catch((error) => {
+                if (error.response?.data?.errors) {
+                    setErrorMsg(error.response.data.errors.map(e => e.msg).join(' '));
+                } else {
+                    setErrorMsg('Registration failed. Please try again.');
+                }
+                setShowRecaptcha(false);
+            });
     }
+
 
     function handleOtpSubmit(e) {
         e.preventDefault();

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -5,14 +5,5 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite",
-  "installCommand": "npm install",
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
-        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" }
-      ]
-    }
-  ]
+  "installCommand": "npm install"
 }


### PR DESCRIPTION
This PR:
- Disables reCAPTCHA on localhost (avoids 'Localhost is not in the list of supported domains' error).
- Removes COOP/COEP headers from vercel.json to avoid blocking third-party scripts like Google reCAPTCHA.
- Fixes missing /api prefixes in frontend API calls to prevent 404s.
- Adds a registration-specific rate limiter to reduce accidental 429s during legitimate signups.

Build and tests:
- Frontend production build succeeded locally.

Please review and merge to trigger the hosted deployments (Vercel/Render).

## Summary by Sourcery

Adjust registration flow, rate limiting, and frontend API integration to improve reliability and local development behavior.

Bug Fixes:
- Correct frontend API endpoints to use the /api prefix for project collaboration and user listing calls.

Enhancements:
- Disable reCAPTCHA during localhost development while allowing it in deployed environments.
- Extract registration logic into a reusable helper to support flows with and without reCAPTCHA.
- Introduce a dedicated, slightly more permissive rate limiter for user registration to reduce false-positive 429 responses.