### PR TITLE
fix(recaptcha): scope Escape to modal; test: fail on non-JSON register responses.

### DIFF
--- a/frontend/src/screens/Register.jsx
+++ b/frontend/src/screens/Register.jsx
@@ -87,7 +87,9 @@ const Register = () => {
 
     // Manage focus when the recaptcha modal opens and closes to follow
     // accessible dialog patterns: move focus into the dialog and restore
-    // it when closed; handle Escape to close the dialog.
+    // it when closed. Use the modal element's keyboard handler instead of
+    // a global window listener so Escape handling doesn't leak to other
+    // parts of the page or other dialogs.
     useEffect(() => {
         if (showRecaptcha) {
             try {
@@ -97,17 +99,14 @@ const Register = () => {
             }
             const focusTimeout = setTimeout(() => {
                 try {
-                    if (modalRef.current && typeof modalRef.current.focus === 'function') modalRef.current.focus();
+                    if (modalRef.current && typeof modalRef.current.focus === 'function') {
+                        modalRef.current.focus();
+                    }
                 } catch (e) {}
             }, 50);
 
-            const onKey = (e) => {
-                if (e.key === 'Escape') setShowRecaptcha(false);
-            };
-            window.addEventListener('keydown', onKey);
             return () => {
                 clearTimeout(focusTimeout);
-                window.removeEventListener('keydown', onKey);
             };
         }
 
@@ -315,7 +314,12 @@ const Register = () => {
                     </button>
                     {showRecaptcha && (
                         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" role="dialog" aria-modal="true">
-                            <div className={`${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'} rounded-lg shadow-2xl p-8 w-full max-w-sm flex flex-col items-center`} tabIndex={-1}>
+                            <div
+                                ref={modalRef}
+                                onKeyDown={(e) => { if (e.key === 'Escape') setShowRecaptcha(false); }}
+                                className={`${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'} rounded-lg shadow-2xl p-8 w-full max-w-sm flex flex-col items-center`}
+                                tabIndex={-1}
+                            >
                                 <ReCAPTCHA
                                     sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
                                     onChange={handleRecaptcha}

--- a/scripts/test_register.js
+++ b/scripts/test_register.js
@@ -76,12 +76,14 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
       process.exit(1);
     }
 
-    // Try parsing JSON body for clearer output when available
+    // Registration endpoint is expected to return JSON in normal operation.
+    // Treat non-JSON responses as a hard failure to catch regressions (e.g. HTML error pages).
     try {
       const parsed = registerResp.body ? JSON.parse(registerResp.body) : {};
       console.log('Parsed register JSON:', parsed);
     } catch (err) {
-      console.warn('Register response is not valid JSON:', err);
+      console.error('Registration response is not valid JSON:', { error: err, body: registerResp.body });
+      process.exit(1);
     }
   } catch (e) {
     console.error('test script error', e);


### PR DESCRIPTION
fix(recaptcha): scope Escape to modal; test: fail on non-JSON register responses.

## Summary by Sourcery

Scope the reCAPTCHA modal keyboard handling to the modal element and harden the registration test script against non-JSON responses.

Bug Fixes:
- Limit Escape key handling for the reCAPTCHA dialog to the modal element to avoid interfering with other parts of the page.

Enhancements:
- Tighten the registration test script to treat non-JSON register endpoint responses as failures, surfacing regressions like HTML error pages more clearly.