### PR TITLE
test: use happy-dom for Vitest; improve test_register error handling and add context

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -68,6 +68,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.0",
         "globals": "^17.4.0",
+        "happy-dom": "^9.20.3",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.3.0",
         "jsdom": "^29.0.1",
@@ -12212,6 +12213,68 @@
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
       "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
       "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+    },
+    "node_modules/happy-dom": {
+      "version": "9.20.3",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-9.20.3.tgz",
+      "integrity": "sha512-eBsgauT435fXFvQDNcmm5QbGtYzxEzOaX35Ia+h6yP/wwa4xSWZh1CfP+mGby8Hk6Xu59mTkpyf72rUXHNxY7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css.escape": "^1.5.1",
+        "entities": "^4.5.0",
+        "iconv-lite": "^0.6.3",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.0",
     "globals": "^17.4.0",
+    "happy-dom": "^9.20.3",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.3.0",
     "jsdom": "^29.0.1",

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -19,7 +19,7 @@ export default defineConfig({
     },
   },
   test: {
-    environment: 'jsdom',
+    environment: 'happy-dom',
   setupFiles: ['./register-css-mock.js', './jest.setup.js'],
     globals: true,
     coverage: {

--- a/scripts/test_register.js
+++ b/scripts/test_register.js
@@ -44,9 +44,10 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
     try {
       json = tokenResp.body ? JSON.parse(tokenResp.body) : {};
     } catch (err) {
-      console.error('Failed to parse /csrf-token JSON response:', err);
-      console.error('Response body:', tokenResp.body);
-      process.exit(1);
+      const parseErr = new Error('Failed to parse /csrf-token JSON response');
+      parseErr.cause = err;
+      parseErr.details = { body: tokenResp.body, status: tokenResp.status, headers: tokenResp.headers };
+      throw parseErr;
     }
 
     const csrfToken = json.csrfToken;
@@ -54,12 +55,14 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
     console.log('csrfToken', csrfToken ? 'present' : 'missing', 'signed', signed ? 'present' : 'missing');
 
     if (!csrfToken) {
-      console.error('No csrfToken returned from /csrf-token; aborting test.');
-      process.exit(1);
+      const err = new Error('No csrfToken returned from /csrf-token; aborting test.');
+      err.details = { status: tokenResp.status, headers: tokenResp.headers, body: tokenResp.body };
+      throw err;
     }
     if (!setCookie) {
-      console.error('No Set-Cookie header returned from /csrf-token; cookies may be blocked. Aborting.');
-      process.exit(1);
+      const err = new Error('No Set-Cookie header returned from /csrf-token; cookies may be blocked. Aborting.');
+      err.details = { status: tokenResp.status, headers: tokenResp.headers, body: tokenResp.body };
+      throw err;
     }
 
     const testEmail = `test+${Date.now()}@example.com`;
@@ -72,8 +75,9 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
 
     // Fail fast on unexpected HTTP status codes so test failures are obvious
     if (registerResp.status < 200 || registerResp.status >= 300) {
-      console.error('Registration failed with unexpected status', { status: registerResp.status, body: registerResp.body });
-      process.exit(1);
+      const statusErr = new Error('Registration failed with unexpected status ' + registerResp.status);
+      statusErr.details = { status: registerResp.status, headers: registerResp.headers, body: registerResp.body };
+      throw statusErr;
     }
 
     // Registration endpoint is expected to return JSON in normal operation.
@@ -82,11 +86,22 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
       const parsed = registerResp.body ? JSON.parse(registerResp.body) : {};
       console.log('Parsed register JSON:', parsed);
     } catch (err) {
-      console.error('Registration response is not valid JSON:', { error: err, body: registerResp.body });
-      process.exit(1);
+      const parseErr = new Error('Registration response is not valid JSON');
+      parseErr.details = {
+        error: err,
+        status: registerResp.status,
+        headers: {
+          'content-type': registerResp.headers?.['content-type'] ?? registerResp.headers?.['Content-Type'],
+          location: registerResp.headers?.location ?? registerResp.headers?.Location,
+          raw: registerResp.headers,
+        },
+        body: registerResp.body,
+      };
+      throw parseErr;
     }
   } catch (e) {
     console.error('test script error', e);
+    if (e && e.details) console.error('details:', e.details);
     process.exit(1);
   }
 })();


### PR DESCRIPTION
test: use happy-dom for Vitest; improve test_register error handling and add context

## Summary by Sourcery

Switch Vitest to use the happy-dom environment and improve error reporting in the test register script.

Bug Fixes:
- Improve error handling in test_register.js by throwing structured errors instead of exiting immediately, including additional response context for easier debugging.

Enhancements:
- Log detailed error context from test_register.js in a single catch block, including HTTP status, headers, and bodies where relevant.

Tests:
- Configure Vitest to run with the happy-dom environment instead of jsdom and add the corresponding dependency.