### PR TITLE
test: support HTTPS and throw detailed errors from fetchWithCookies

### DIFF
--- a/scripts/test_register.js
+++ b/scripts/test_register.js
@@ -96,6 +96,21 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
     try {
       const parsed = registerResp.body ? JSON.parse(registerResp.body) : {};
       console.log('Parsed register JSON:', parsed);
+      // If the server returned an OTP (common in dev/test), verify it to complete login flow
+      if (parsed && parsed.otp && parsed.userId) {
+        console.log('Verifying returned OTP to complete login flow...');
+        const verifyResp = await fetchWithCookies(`${base}/api/users/verify-otp`, { method: 'POST', body: JSON.stringify({ userId: parsed.userId, otp: parsed.otp }), headers: { 'X-XSRF-TOKEN': csrfToken } }, Array.isArray(setCookie) ? setCookie.join('; ') : (setCookie || ''));
+        console.log('verify status', verifyResp.status);
+        console.log('verify body', verifyResp.body);
+        try {
+          const vparsed = verifyResp.body ? JSON.parse(verifyResp.body) : {};
+          console.log('Parsed verify JSON:', vparsed);
+        } catch (err) {
+          const ve = new Error('Verify response is not valid JSON');
+          ve.details = { error: err, status: verifyResp.status, headers: verifyResp.headers, body: verifyResp.body };
+          throw ve;
+        }
+      }
     } catch (err) {
       const parseErr = new Error('Registration response is not valid JSON');
       parseErr.details = {

--- a/scripts/test_register.js
+++ b/scripts/test_register.js
@@ -1,4 +1,5 @@
 import http from 'http';
+import https from 'https';
 import { URL } from 'url';
 
 async function fetchWithCookies(url, options = {}, cookies = '') {
@@ -9,10 +10,12 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
   if (options.body && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
 
   return new Promise((resolve, reject) => {
-    const req = http.request(
+    const transport = u.protocol === 'https:' ? https : http;
+    const port = u.port || (u.protocol === 'https:' ? 443 : 80);
+    const req = transport.request(
       {
         hostname: u.hostname,
-        port: u.port,
+        port,
         path: u.pathname + (u.search || ''),
         method: options.method || 'GET',
         headers,
@@ -22,7 +25,15 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
         res.on('data', c => chunks.push(c));
         res.on('end', () => {
           const body = Buffer.concat(chunks).toString('utf8');
-          resolve({ status: res.statusCode, headers: res.headers, body });
+          const response = { status: res.statusCode, headers: res.headers, body };
+          // Reject on HTTP errors so callers can decide how to handle them
+          if (res.statusCode >= 400) {
+            const err = new Error('HTTP Error: ' + res.statusCode);
+            err.details = response;
+            reject(err);
+            return;
+          }
+          resolve(response);
         });
       }
     ).on('error', reject);

--- a/scripts/test_register.js
+++ b/scripts/test_register.js
@@ -2,6 +2,86 @@ import http from 'http';
 import https from 'https';
 import { URL } from 'url';
 
+// Small helper Error class so we consistently attach `details` and
+// preserve an optional `cause`. Centralizing makes tests easier to
+// handle and avoids ad-hoc attachment of properties on Error instances.
+class TestError extends Error {
+  constructor(message, details = {}, cause) {
+    super(message);
+    this.name = 'TestError';
+    if (cause) this.cause = cause;
+    this.details = details;
+  }
+}
+
+// Helpers to sanitize headers/body before logging so CI/shared logs
+// don't leak cookies, tokens or large payloads. We keep content-type
+// and location, but redact cookies and authorization headers.
+const SENSITIVE_HEADER_KEYS = ['set-cookie', 'cookie', 'authorization'];
+function sanitizeHeaders(headers = {}) {
+  const out = {};
+  try {
+    for (const k of Object.keys(headers || {})) {
+      const lk = k.toLowerCase();
+      if (SENSITIVE_HEADER_KEYS.includes(lk)) {
+        out[k] = '<redacted>';
+      } else if (lk === 'content-type' || lk === 'location') {
+        out[k] = headers[k];
+      } else {
+        // keep small non-sensitive headers but avoid dumping huge raw objects
+        const v = headers[k];
+        if (typeof v === 'string' && v.length < 200) out[k] = v;
+      }
+    }
+  } catch (e) {
+    return { error: '<failed to sanitize headers>' };
+  }
+  return out;
+}
+
+const SENSITIVE_BODY_KEYS = new Set(['token', 'otp', 'password', 'authorization']);
+function maskObjectSensitive(obj) {
+  if (!obj || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(maskObjectSensitive);
+  const out = {};
+  for (const k of Object.keys(obj)) {
+    try {
+      if (SENSITIVE_BODY_KEYS.has(k.toLowerCase())) {
+        out[k] = '<redacted>';
+      } else if (typeof obj[k] === 'object') {
+        out[k] = maskObjectSensitive(obj[k]);
+      } else if (typeof obj[k] === 'string' && obj[k].length > 500) {
+        out[k] = obj[k].slice(0, 200) + '...<truncated>';
+      } else {
+        out[k] = obj[k];
+      }
+    } catch (e) {
+      out[k] = '<unable to read>';
+    }
+  }
+  return out;
+}
+
+function sanitizeBody(body) {
+  if (body == null) return body;
+  if (typeof body !== 'string') return body;
+  try {
+    const parsed = JSON.parse(body);
+    return maskObjectSensitive(parsed);
+  } catch (e) {
+    // Not JSON - truncate long HTML/error pages to avoid leaking content
+    return body.length > 1000 ? body.slice(0, 1000) + '...<truncated>' : body;
+  }
+}
+
+function sanitizeResponse(resp = {}) {
+  return {
+    status: resp.status,
+    headers: sanitizeHeaders(resp.headers),
+    body: sanitizeBody(resp.body),
+  };
+}
+
 async function fetchWithCookies(url, options = {}, cookies = '') {
   const u = new URL(url);
   const headers = Object.assign({}, options.headers || {});
@@ -55,10 +135,7 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
     try {
       json = tokenResp.body ? JSON.parse(tokenResp.body) : {};
     } catch (err) {
-      const parseErr = new Error('Failed to parse /csrf-token JSON response');
-      parseErr.cause = err;
-      parseErr.details = { body: tokenResp.body, status: tokenResp.status, headers: tokenResp.headers };
-      throw parseErr;
+      throw new TestError('Failed to parse /csrf-token JSON response', sanitizeResponse(tokenResp), err);
     }
 
     const csrfToken = json.csrfToken;
@@ -66,14 +143,10 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
     console.log('csrfToken', csrfToken ? 'present' : 'missing', 'signed', signed ? 'present' : 'missing');
 
     if (!csrfToken) {
-      const err = new Error('No csrfToken returned from /csrf-token; aborting test.');
-      err.details = { status: tokenResp.status, headers: tokenResp.headers, body: tokenResp.body };
-      throw err;
+      throw new TestError('No csrfToken returned from /csrf-token; aborting test.', sanitizeResponse(tokenResp));
     }
     if (!setCookie) {
-      const err = new Error('No Set-Cookie header returned from /csrf-token; cookies may be blocked. Aborting.');
-      err.details = { status: tokenResp.status, headers: tokenResp.headers, body: tokenResp.body };
-      throw err;
+      throw new TestError('No Set-Cookie header returned from /csrf-token; cookies may be blocked. Aborting.', sanitizeResponse(tokenResp));
     }
 
     const testEmail = `test+${Date.now()}@example.com`;
@@ -82,52 +155,46 @@ async function fetchWithCookies(url, options = {}, cookies = '') {
     const registerResp = await fetchWithCookies(`${base}/api/users/register`, { method: 'POST', body: JSON.stringify(payload), headers: { 'X-XSRF-TOKEN': csrfToken } }, Array.isArray(setCookie) ? setCookie.join('; ') : (setCookie || ''));
 
     console.log('register status', registerResp.status);
-    console.log('register body:', registerResp.body);
+    console.log('register response (sanitized):', sanitizeResponse(registerResp));
 
     // Fail fast on unexpected HTTP status codes so test failures are obvious
     if (registerResp.status < 200 || registerResp.status >= 300) {
-      const statusErr = new Error('Registration failed with unexpected status ' + registerResp.status);
-      statusErr.details = { status: registerResp.status, headers: registerResp.headers, body: registerResp.body };
-      throw statusErr;
+      throw new TestError('Registration failed with unexpected status ' + registerResp.status, sanitizeResponse(registerResp));
     }
 
     // Registration endpoint is expected to return JSON in normal operation.
     // Treat non-JSON responses as a hard failure to catch regressions (e.g. HTML error pages).
     try {
       const parsed = registerResp.body ? JSON.parse(registerResp.body) : {};
-      console.log('Parsed register JSON:', parsed);
+      console.log('Parsed register JSON (sanitized):', maskObjectSensitive(parsed));
       // If the server returned an OTP (common in dev/test), verify it to complete login flow
       if (parsed && parsed.otp && parsed.userId) {
         console.log('Verifying returned OTP to complete login flow...');
         const verifyResp = await fetchWithCookies(`${base}/api/users/verify-otp`, { method: 'POST', body: JSON.stringify({ userId: parsed.userId, otp: parsed.otp }), headers: { 'X-XSRF-TOKEN': csrfToken } }, Array.isArray(setCookie) ? setCookie.join('; ') : (setCookie || ''));
-        console.log('verify status', verifyResp.status);
-        console.log('verify body', verifyResp.body);
+        console.log('verify response (sanitized):', sanitizeResponse(verifyResp));
         try {
           const vparsed = verifyResp.body ? JSON.parse(verifyResp.body) : {};
-          console.log('Parsed verify JSON:', vparsed);
+          console.log('Parsed verify JSON (sanitized):', maskObjectSensitive(vparsed));
         } catch (err) {
-          const ve = new Error('Verify response is not valid JSON');
-          ve.details = { error: err, status: verifyResp.status, headers: verifyResp.headers, body: verifyResp.body };
-          throw ve;
+          throw new TestError('Verify response is not valid JSON', sanitizeResponse(verifyResp), err);
         }
       }
     } catch (err) {
-      const parseErr = new Error('Registration response is not valid JSON');
-      parseErr.details = {
-        error: err,
-        status: registerResp.status,
-        headers: {
-          'content-type': registerResp.headers?.['content-type'] ?? registerResp.headers?.['Content-Type'],
-          location: registerResp.headers?.location ?? registerResp.headers?.Location,
-          raw: registerResp.headers,
-        },
-        body: registerResp.body,
-      };
-      throw parseErr;
+      throw new TestError('Registration response is not valid JSON', sanitizeResponse(registerResp), err);
     }
   } catch (e) {
-    console.error('test script error', e);
-    if (e && e.details) console.error('details:', e.details);
+    // Print a short error message and sanitized details to avoid leaking secrets
+    console.error('test script error', e && e.message ? e.message : e);
+    if (e && e.details) {
+      // e.details might already be a sanitized response (we used sanitizeResponse when throwing),
+      // but in case it isn't, normalize / sanitize the known shapes.
+      const details = e.details && e.details.status ? sanitizeResponse(e.details) : {
+        ...(e.details || {}),
+        headers: sanitizeHeaders(e.details?.headers),
+        body: sanitizeBody(e.details?.body),
+      };
+      console.error('details:', details);
+    }
     process.exit(1);
   }
 })();


### PR DESCRIPTION
test: support HTTPS and throw detailed errors from fetchWithCookies

## Summary by Sourcery

Add HTTPS support and improved error handling to the test registration helper script.

New Features:
- Support making HTTPS requests in the test registration helper via fetchWithCookies.
- Automatically complete the OTP verification step in the test registration flow when an OTP is returned.

Bug Fixes:
- Reject HTTP error responses from fetchWithCookies with detailed error information instead of treating them as successful responses.
- Provide clearer JSON parsing errors for registration and OTP verification responses, including response details for easier debugging.

Tests:
- Enhance the test registration flow to optionally verify OTP codes returned by the server, better simulating a full login process during tests.