### PR TITLE
fix(security+mail): strict OTP exposure + SMTP verify+retry mailer; refactor user controller to use mailer util

### DIFF
--- a/Backend/controllers/user.controller.js
+++ b/Backend/controllers/user.controller.js
@@ -31,18 +31,11 @@ export const getLeaderboardController = async (req, res) => {
 };
 import userModel from '../models/user.model.js';
 import { normalizeEmail } from '../utils/email.js';
-import nodemailer from 'nodemailer';
+import { shouldExposeOtpToClient } from '../utils/security.js';
+import { sendMailWithRetry } from '../utils/mailer.js';
 import dotenv from 'dotenv';
 dotenv.config();
 
-// Decide whether it's safe to expose OTPs to API responses. Defaults to
-// conservative behavior (don't expose) unless explicitly allowed via
-// `EXPOSE_OTP=true` or when running in clear development/test modes.
-function shouldExposeOtpToClient() {
-    if (String(process.env.EXPOSE_OTP).toLowerCase() === 'true') return true;
-    const env = String(process.env.NODE_ENV || 'production').toLowerCase();
-    return env === 'development' || env === 'test';
-}
 // Helper: escape user-supplied text before inserting into HTML templates
 function escapeHtml(unsafe) {
     if (unsafe === undefined || unsafe === null) return '';
@@ -121,26 +114,20 @@ async function sendOtpEmail(email, otp) {
     // In test environments skip sending real emails to avoid external
     // dependencies and flaky failures when SMTP creds are not configured.
     if (process.env.NODE_ENV === 'test') {
-        console.log('Skipping email send in test environment (OTP:', otp, ')');
+        console.log('Skipping email send in test environment');
         return;
     }
 
-    const transporter = nodemailer.createTransport({
-        host: process.env.SMTP_HOST,
-        port: process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT) : 587,
-        secure: false,
-        auth: {
-            user: process.env.SMTP_USER,
-            pass: process.env.SMTP_PASS,
-        },
-    });
-    let info = await transporter.sendMail({
+    const mailOptions = {
         from: process.env.SMTP_FROM || 'ChatRaj <no-reply@chatraj.com>',
         to: email,
         subject: 'Your ChatRaj OTP Verification',
-        text: `Welcome to ChatRaj!\n\nYour OTP is: ${otp}\n\nPlease enter this code in the registration popup to activate your account.`
-    });
-    console.log('OTP email sent: %s', info.messageId);
+        text: `Welcome to ChatRaj!\n\nYour OTP is: ${otp}\n\nPlease enter this code in the registration popup to activate your account.`,
+    };
+
+    // Use robust send with retry/backoff. Any thrown error will be
+    // propagated to the caller so registration flow can respond safely.
+    await sendMailWithRetry(mailOptions);
 }
 
 // OTP verification for both registration (userId) and password reset (email)
@@ -304,15 +291,6 @@ async function sendPasswordResetSuccessEmail(email, name) {
         return;
     }
 
-    const transporter = nodemailer.createTransport({
-        host: process.env.SMTP_HOST,
-        port: process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT) : 587,
-        secure: false,
-        auth: {
-            user: process.env.SMTP_USER,
-            pass: process.env.SMTP_PASS,
-        },
-    });
     const html = `
       <div style="font-family: 'Segoe UI', Arial, sans-serif; background: #f4f8fc; padding: 40px; border-radius: 16px; color: #222; box-shadow: 0 4px 24px rgba(37,99,235,0.08);">
         <div style="text-align:center;">
@@ -340,11 +318,11 @@ async function sendPasswordResetSuccessEmail(email, name) {
         </div>
       </div>
     `;
-    let info = await transporter.sendMail({
+    const mailOptions = {
         from: process.env.SMTP_FROM || 'ChatRaj <no-reply@chatraj.com>',
         to: typeof email === 'string' ? email.trim() : email,
         subject: 'Your ChatRaj Password Has Been Reset',
-        html
-    });
-    console.log('Password reset success email sent: %s', info.messageId);
+        html,
+    };
+    await sendMailWithRetry(mailOptions);
 }

--- a/Backend/utils/mailer.js
+++ b/Backend/utils/mailer.js
@@ -1,0 +1,68 @@
+import nodemailer from 'nodemailer';
+
+const DEFAULT_RETRIES = parseInt(process.env.SMTP_RETRY_COUNT || '3', 10);
+const DEFAULT_BACKOFF_MS = parseInt(process.env.SMTP_RETRY_BACKOFF_MS || '500', 10);
+
+function createTransporter() {
+  if (!process.env.SMTP_HOST || !process.env.SMTP_USER || !process.env.SMTP_PASS) {
+    throw new Error('SMTP configuration missing (SMTP_HOST/SMTP_USER/SMTP_PASS)');
+  }
+  const port = process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT, 10) : 587;
+  const secure = port === 465;
+  return nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port,
+    secure,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+    connectionTimeout: parseInt(process.env.SMTP_CONNECTION_TIMEOUT_MS || '10000', 10),
+  });
+}
+
+function verifyTransporter(transporter) {
+  return new Promise((resolve, reject) => {
+    transporter.verify((err, success) => {
+      if (err) return reject(err);
+      return resolve(success);
+    });
+  });
+}
+
+export async function sendMailWithRetry(mailOptions, opts = {}) {
+  const retries = typeof opts.retries === 'number' ? opts.retries : DEFAULT_RETRIES;
+  const backoff = typeof opts.backoff === 'number' ? opts.backoff : DEFAULT_BACKOFF_MS;
+
+  const transporter = createTransporter();
+
+  // Best-effort verify; some providers may not support verify(), but
+  // a failure here is only informational — we still attempt to send.
+  try {
+    await verifyTransporter(transporter);
+  } catch (err) {
+    console.error('SMTP verify failed (continuing to send attempts):', err && err.message ? err.message : err);
+  }
+
+  let lastErr = null;
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const info = await transporter.sendMail(mailOptions);
+      console.info('SMTP: message sent to %s (messageId=%s)', mailOptions.to, info && info.messageId ? info.messageId : 'unknown');
+      return info;
+    } catch (err) {
+      lastErr = err;
+      console.error(`SMTP send attempt ${attempt} failed:`, err && err.message ? err.message : err);
+      if (attempt < retries) {
+        const wait = backoff * Math.pow(2, attempt - 1);
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, wait));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+export default {
+  sendMailWithRetry,
+};

--- a/Backend/utils/security.js
+++ b/Backend/utils/security.js
@@ -1,0 +1,9 @@
+// Utilities around exposing sensitive data in responses.
+// By default we are conservative: do NOT expose OTPs unless explicitly
+// enabled via EXPOSE_OTP=true. This avoids accidental leaks when
+// `NODE_ENV` is unset or misconfigured on hosted environments.
+export function shouldExposeOtpToClient() {
+  return String(process.env.EXPOSE_OTP || '').toLowerCase() === 'true';
+}
+
+export default shouldExposeOtpToClient;


### PR DESCRIPTION
fix(security+mail): strict OTP exposure + SMTP verify+retry mailer; refactor user controller to use mailer util

## Summary by Sourcery

Introduce a reusable, verified, retry-capable SMTP mailer utility and tighten OTP exposure configuration.

New Features:
- Add a centralized mailer utility that configures nodemailer with verification, exponential backoff, and retry support for SMTP sends.
- Add a dedicated security utility to control whether OTPs may be exposed to API clients via an environment flag.

Bug Fixes:
- Harden OTP exposure rules to default to non-exposure unless explicitly enabled, avoiding accidental leaks in misconfigured environments.

Enhancements:
- Refactor user controller email flows to use the shared mailer utility instead of inline nodemailer setup for OTP and password reset notifications.