### PR TITLE
Fix OTP sending issue.

### DIFF
--- a/Backend/controllers/user.controller.js
+++ b/Backend/controllers/user.controller.js
@@ -78,7 +78,7 @@ export const createUserController = async (req, res) => {
             // need the OTP for debugging, enable `EXPOSE_OTP=true` in a safe
             // environment and inspect server logs — but do NOT return it to
             // the client to avoid accidental leakage.
-            if (String(process.env.EXPOSE_OTP || '').toLowerCase() === 'true' && String(process.env.CI || '').toLowerCase() !== 'true') {
+            if (shouldExposeOtpToClient()) {
                 try {
                     // Log only a masked version of the OTP to avoid plain-text
                     // leakage in logs: show length and the first/last char.
@@ -89,7 +89,6 @@ export const createUserController = async (req, res) => {
                 }
             }
             return res.status(201).json({ message: 'Account created. We could not send a verification email — please contact support or try again later.', userId: user._id });
-        }
         }
     } catch (error) {
         console.error('createUserController error:', error && error.message ? error.message : error);
@@ -160,6 +159,35 @@ export const verifyOtpController = async (req, res) => {
     let token = null;
     if (userId) token = await user.generateJWT();
     res.status(200).json({ message: 'Verified successfully', token, user });
+};
+
+// Admin-only: retrieve masked OTP for debugging. Requires `ADMIN_API_KEY`
+export const adminGetOtpController = async (req, res) => {
+    try {
+        const adminKey = req.get('x-admin-key');
+        if (!process.env.ADMIN_API_KEY) return res.status(403).json({ message: 'Admin API key not configured on server' });
+        if (!adminKey || adminKey !== process.env.ADMIN_API_KEY) return res.status(403).json({ message: 'Forbidden' });
+
+        const { email, userId } = req.query;
+        if (!email && !userId) return res.status(400).json({ message: 'Provide email or userId' });
+
+        let user;
+        if (userId) {
+            if (typeof userId !== 'string' || !mongoose.Types.ObjectId.isValid(userId)) return res.status(400).json({ message: 'Invalid userId' });
+            user = await userModel.findById(userId).select('+otp');
+        } else {
+            const { value: normalizedEmail, isValid } = normalizeEmail(email);
+            if (!isValid) return res.status(400).json({ message: 'Valid email is required' });
+            user = await userModel.findOne({ email: normalizedEmail }).select('+otp');
+        }
+        if (!user) return res.status(404).json({ message: 'User not found' });
+        const otp = user.otp;
+        const masked = typeof otp === 'string' && otp.length > 2 ? `${otp[0]}***${otp[otp.length - 1]}` : '<redacted>';
+        return res.status(200).json({ userId: user._id, email: user.email, maskedOtp: masked });
+    } catch (err) {
+        console.error('adminGetOtpController error:', err);
+        return res.status(500).json({ message: 'Internal server error' });
+    }
 };
 
 export const loginController = async (req, res) => {

--- a/Backend/routes/user.routes.js
+++ b/Backend/routes/user.routes.js
@@ -43,6 +43,9 @@ router.post('/register',
 
 router.post('/verify-otp', sensitiveLimiter, userController.verifyOtpController);
 
+// Admin-only endpoint to fetch masked OTPs for debugging. Requires ADMIN_API_KEY header `x-admin-key`.
+router.get('/admin/otp', sensitiveLimiter, userController.adminGetOtpController);
+
 router.post('/login',
   body('email').isEmail().withMessage('Email must be a valid email address'),
   body('password').isLength({ min: 3 }).withMessage('Password must be at least 3 characters long'),

--- a/Backend/utils/mailer.js
+++ b/Backend/utils/mailer.js
@@ -1,15 +1,28 @@
 import nodemailer from 'nodemailer';
+import { URL } from 'url';
 
-const DEFAULT_RETRIES = parseInt(process.env.SMTP_RETRY_COUNT || '3', 10);
+const DEFAULT_RETRIES = Math.max(1, parseInt(process.env.SMTP_RETRY_COUNT || '3', 10));
 const DEFAULT_BACKOFF_MS = parseInt(process.env.SMTP_RETRY_BACKOFF_MS || '500', 10);
 
+let transporterInstance = null;
+
+function missingSmtpKeys() {
+  const missing = [];
+  if (!process.env.SMTP_HOST) missing.push('SMTP_HOST');
+  if (!process.env.SMTP_USER) missing.push('SMTP_USER');
+  if (!process.env.SMTP_PASS) missing.push('SMTP_PASS');
+  return missing;
+}
+
 function createTransporter() {
-  if (!process.env.SMTP_HOST || !process.env.SMTP_USER || !process.env.SMTP_PASS) {
-    throw new Error('SMTP configuration missing (SMTP_HOST/SMTP_USER/SMTP_PASS)');
+  if (transporterInstance) return transporterInstance;
+  const missing = missingSmtpKeys();
+  if (missing.length) {
+    throw new Error(`SMTP configuration missing: ${missing.join(', ')}`);
   }
   const port = process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT, 10) : 587;
   const secure = port === 465;
-  return nodemailer.createTransport({
+  transporterInstance = nodemailer.createTransport({
     host: process.env.SMTP_HOST,
     port,
     secure,
@@ -19,6 +32,7 @@ function createTransporter() {
     },
     connectionTimeout: parseInt(process.env.SMTP_CONNECTION_TIMEOUT_MS || '10000', 10),
   });
+  return transporterInstance;
 }
 
 function verifyTransporter(transporter) {
@@ -30,8 +44,38 @@ function verifyTransporter(transporter) {
   });
 }
 
+async function sendWebhookNotification(webhookUrl, payload) {
+  try {
+    const u = new URL(webhookUrl);
+    const lib = u.protocol === 'https:' ? await import('https') : await import('http');
+    const body = JSON.stringify(payload);
+    const opts = {
+      method: 'POST',
+      hostname: u.hostname,
+      port: u.port || (u.protocol === 'https:' ? 443 : 80),
+      path: u.pathname + (u.search || ''),
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+    };
+    await new Promise((resolve, reject) => {
+      const req = lib.request(opts, (res) => {
+        // consume response
+        res.on('data', () => {});
+        res.on('end', resolve);
+      });
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
+  } catch (err) {
+    console.error('SMTP failure webhook notify failed:', err && err.message ? err.message : err);
+  }
+}
+
 export async function sendMailWithRetry(mailOptions, opts = {}) {
-  const retries = typeof opts.retries === 'number' ? opts.retries : DEFAULT_RETRIES;
+  const retries = Math.max(1, (typeof opts.retries === 'number' ? opts.retries : DEFAULT_RETRIES));
   const backoff = typeof opts.backoff === 'number' ? opts.backoff : DEFAULT_BACKOFF_MS;
 
   const transporter = createTransporter();
@@ -60,7 +104,23 @@ export async function sendMailWithRetry(mailOptions, opts = {}) {
       }
     }
   }
-  throw lastErr;
+
+  // Optionally notify an external webhook that SMTP failed repeatedly.
+  if (process.env.SMTP_FAILURE_WEBHOOK) {
+    try {
+      await sendWebhookNotification(process.env.SMTP_FAILURE_WEBHOOK, {
+        timestamp: new Date().toISOString(),
+        to: mailOptions.to,
+        subject: mailOptions.subject,
+        error: (lastErr && (lastErr.message || String(lastErr))) || 'unknown',
+      });
+    } catch (notifyErr) {
+      console.error('Failed to send SMTP failure notification:', notifyErr && notifyErr.message ? notifyErr.message : notifyErr);
+    }
+  }
+
+  if (lastErr) throw lastErr;
+  throw new Error('SMTP send failed after attempts but no error captured');
 }
 
 export default {

--- a/Backend/utils/security.js
+++ b/Backend/utils/security.js
@@ -3,7 +3,11 @@
 // enabled via EXPOSE_OTP=true. This avoids accidental leaks when
 // `NODE_ENV` is unset or misconfigured on hosted environments.
 export function shouldExposeOtpToClient() {
-  return String(process.env.EXPOSE_OTP || '').toLowerCase() === 'true';
+  // Require an explicit opt-in via EXPOSE_OTP=true and ensure not running
+  // in CI environments. This avoids accidental exposure in staging/dev.
+  const expose = String(process.env.EXPOSE_OTP || '').toLowerCase() === 'true';
+  const ci = String(process.env.CI || '').toLowerCase() === 'true';
+  return expose && !ci;
 }
 
 export default shouldExposeOtpToClient;


### PR DESCRIPTION
Fix OTP sending issue.

## Summary by Sourcery

Improve reliability and observability of OTP email delivery while tightening OTP exposure controls and adding an admin-only debugging endpoint.

New Features:
- Add an admin-only endpoint to retrieve a masked OTP for a user by email or userId using an ADMIN_API_KEY-protected API.

Bug Fixes:
- Prevent SMTP retry counts from being zero or negative, ensuring at least one email send attempt.
- Fix OTP exposure logic to centralize and correctly gate when OTPs may be exposed to clients outside CI environments.
- Improve SMTP configuration validation by explicitly reporting which required environment variables are missing.

Enhancements:
- Introduce a cached Nodemailer transporter instance to avoid recreating the transporter on every send.
- Add optional webhook notifications when SMTP delivery fails after all retry attempts, including basic context about the failure.