### PR TITLE
add retry_pending_registrations script and npm entry; retry worker for pending OTPs

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
+    "retry-pending-registrations": "node scripts/retry_pending_registrations.js",
     "build": "npm install"
   },
   "dependencies": {

--- a/Backend/scripts/retry_pending_registrations.js
+++ b/Backend/scripts/retry_pending_registrations.js
@@ -1,0 +1,60 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import redisClient from '../services/redis.service.js';
+import { sendMailWithRetry } from '../utils/mailer.js';
+
+async function run() {
+  try {
+    if (typeof redisClient.keys !== 'function') {
+      console.warn('redisClient.keys not available; ensure REDIS_URL is set in production to run this script. Aborting.');
+      process.exit(0);
+    }
+
+    const keys = await redisClient.keys('pending:registration:*');
+    if (!keys || keys.length === 0) {
+      console.info('No pending registrations found');
+      process.exit(0);
+    }
+
+    const ttlDefault = parseInt(process.env.REGISTRATION_OTP_TTL_SECONDS || '900', 10);
+    const maxAttempts = parseInt(process.env.REGISTRATION_SEND_RETRY_ATTEMPTS || '5', 10);
+
+    for (const k of keys) {
+      try {
+        const v = await redisClient.get(k);
+        if (!v) continue;
+        const pending = JSON.parse(v);
+        const sentCount = Number(pending.sentCount || 0);
+        if (sentCount >= maxAttempts) {
+          console.info('Max attempts reached for', pending.email);
+          continue;
+        }
+
+        try {
+          await sendMailWithRetry({
+            from: process.env.SMTP_FROM || 'ChatRaj <no-reply@chatraj.com>',
+            to: pending.email,
+            subject: 'Your ChatRaj OTP Verification',
+            text: `Welcome to ChatRaj!\n\nYour OTP is: ${pending.otp}\n\nPlease enter this code in the registration popup to activate your account.`,
+          }, { retries: 3 });
+
+          pending.lastSentAt = Date.now();
+          pending.sentCount = sentCount + 1;
+          await redisClient.set(k, JSON.stringify(pending), 'EX', ttlDefault);
+          console.info('Resent OTP to', pending.email);
+        } catch (err) {
+          console.error('Failed to resend to', pending.email, err && err.message ? err.message : err);
+        }
+      } catch (err) {
+        console.error('Error processing pending key', k, err && err.message ? err.message : err);
+      }
+    }
+
+    process.exit(0);
+  } catch (err) {
+    console.error('Fatal error in retry script', err && err.message ? err.message : err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/render.yaml
+++ b/render.yaml
@@ -9,3 +9,13 @@ services:
       - key: NODE_ENV
         value: production
     healthCheckPath: /health
+  - type: cron
+    name: retry-pending-registrations
+    env: node
+    rootDir: Backend
+    # Run every 5 minutes; adjust schedule as needed.
+    schedule: "*/5 * * * *"
+    command: "node scripts/retry_pending_registrations.js"
+    envVars:
+      - key: NODE_ENV
+        value: production


### PR DESCRIPTION
add retry_pending_registrations script and npm entry; retry worker for pending OTPs

## Summary by Sourcery

Add a scheduled worker and CLI script to retry sending OTP emails for pending registrations stored in Redis.

New Features:
- Introduce a retry_pending_registrations Node script to resend OTP emails for pending registrations based on Redis keys.
- Expose an npm script to run the pending registration retry logic from the Backend package.
- Configure a Render cron job to run the pending registration retry script every five minutes in production.

Deployment:
- Add a Render cron service configuration to periodically execute the pending registration retry script in the Backend service.