### PR TITLE
fix(redis/mailer): preserve TTL on resend, use SCAN in retry worker, flatten verify flow

### DIFF
--- a/Backend/controllers/user.controller.js
+++ b/Backend/controllers/user.controller.js
@@ -130,12 +130,45 @@ export const createUserController = async (req, res) => {
                     const latest = JSON.parse(latestPendingJson);
                     await sendOtpEmail(latest.email, latest.otp);
                     // on success, update pending metadata (do NOT delete - user
-                    // must still be able to verify using the OTP). Keep TTL.
+                    // must still be able to verify using the OTP). Preserve TTL.
                     try {
                         latest.lastSentAt = Date.now();
                         latest.sentCount = (latest.sentCount || 0) + 1;
-                        const ttl2 = parseInt(process.env.REGISTRATION_OTP_TTL_SECONDS || '900', 10);
-                        await redisClient.set(pendingKey, JSON.stringify(latest), 'EX', ttl2);
+                        const newVal = JSON.stringify(latest);
+                        // Try to update without changing TTL using GETSET (preserves TTL)
+                        if (typeof redisClient.getset === 'function') {
+                            try {
+                                await redisClient.getset(pendingKey, newVal);
+                            } catch (e) {
+                                // fallback to pttl/ttl approach below
+                                throw e;
+                            }
+                        } else {
+                            // Fallback: attempt to read remaining TTL and restore it after set
+                            let remainingMs = null;
+                            if (typeof redisClient.pttl === 'function') {
+                                try {
+                                    remainingMs = await redisClient.pttl(pendingKey);
+                                } catch (e) { remainingMs = null; }
+                            }
+                            if (remainingMs == null && typeof redisClient.ttl === 'function') {
+                                try {
+                                    const secs = await redisClient.ttl(pendingKey);
+                                    if (typeof secs === 'number' && secs >= 0) remainingMs = secs * 1000;
+                                } catch (e) { remainingMs = null; }
+                            }
+                            if (remainingMs != null && remainingMs > 0) {
+                                await redisClient.set(pendingKey, newVal);
+                                if (typeof redisClient.pexpire === 'function') {
+                                    await redisClient.pexpire(pendingKey, remainingMs);
+                                } else if (typeof redisClient.expire === 'function') {
+                                    await redisClient.expire(pendingKey, Math.ceil(remainingMs / 1000));
+                                }
+                            } else {
+                                // Couldn't preserve TTL safely; skip metadata update to avoid extending OTP validity
+                                console.warn('Could not preserve TTL for pending registration; skipping metadata update to avoid extending OTP lifetime');
+                            }
+                        }
                     } catch (updErr) {
                         console.warn('Failed to update pending registration after resend:', updErr && updErr.message ? updErr.message : updErr);
                     }
@@ -210,48 +243,50 @@ export const verifyOtpController = async (req, res) => {
         // If user not found in DB, check for a pending registration stored in Redis
         // (we persist pending registrations there until the user verifies via OTP).
         if (!user) {
+            const pendingKey = `pending:registration:${normalizedEmail}`;
+            let pendingJson = null;
             try {
-                const pendingKey = `pending:registration:${normalizedEmail}`;
-                const pendingJson = await redisClient.get(pendingKey);
-                if (pendingJson) {
-                    const pending = JSON.parse(pendingJson);
-                    if (pending.otp !== otp) return res.status(401).json({ message: 'Invalid OTP' });
-
-                    // Create the real user record from pending values.
-                        try {
-                            const created = await userModel.create({
-                                firstName: pending.firstName,
-                                lastName: pending.lastName,
-                                email: pending.email,
-                                password: pending.passwordHash,
-                                googleApiKey: pending.googleApiKey,
-                                isVerified: true,
-                            });
-                            // remove pending key
-                            await redisClient.del(pendingKey);
-                            // generate token for the newly created user
-                            const token = await created.generateJWT();
-                            // hide password before returning
-                            if (created._doc) delete created._doc.password;
-                            return res.status(200).json({ message: 'Verified successfully', token, user: created });
-                        } catch (createErr) {
-                        console.error('Error creating user from pending registration:', createErr && createErr.message ? createErr.message : createErr);
-                        // If a duplicate key was created in a race, try to mark existing user as verified
-                        if (createErr && (createErr.code === 11000 || createErr.name === 'MongoServerError')) {
-                            const existingUser = await userModel.findOne({ email: normalizedEmail }).select('+otp');
-                            if (existingUser) {
-                                existingUser.isVerified = true;
-                                existingUser.otp = undefined;
-                                await existingUser.save();
-                                const token = await existingUser.generateJWT();
-                                return res.status(200).json({ message: 'Verified successfully', token, user: existingUser });
-                            }
-                        }
-                        return res.status(500).json({ message: 'Failed to create account' });
-                    }
-                }
+                pendingJson = await redisClient.get(pendingKey);
             } catch (redisErr) {
                 console.error('Error checking pending registration in Redis:', redisErr && redisErr.message ? redisErr.message : redisErr);
+            }
+
+            if (pendingJson) {
+                const pending = JSON.parse(pendingJson);
+                if (pending.otp !== otp) return res.status(401).json({ message: 'Invalid OTP' });
+
+                // Create the real user record from pending values.
+                try {
+                    const created = await userModel.create({
+                        firstName: pending.firstName,
+                        lastName: pending.lastName,
+                        email: pending.email,
+                        password: pending.passwordHash,
+                        googleApiKey: pending.googleApiKey,
+                        isVerified: true,
+                    });
+                    // remove pending key
+                    await redisClient.del(pendingKey);
+                    // generate token for the newly created user
+                    const token = await created.generateJWT();
+                    // hide password before returning
+                    if (created._doc) delete created._doc.password;
+                    return res.status(200).json({ message: 'Verified successfully', token, user: created });
+                } catch (createErr) {
+                    console.error('Error creating user from pending registration:', createErr && createErr.message ? createErr.message : createErr);
+                    // If a duplicate key was created in a race, try to mark existing user as verified
+                    if (createErr && (createErr.code === 11000 || createErr.name === 'MongoServerError')) {
+                        const existingUser = await userModel.findOne({ email: normalizedEmail }).select('+otp');
+                        if (existingUser) {
+                            existingUser.isVerified = true;
+                            existingUser.otp = undefined;
+                            await existingUser.save();
+                            const token = await existingUser.generateJWT();
+                            return res.status(200).json({ message: 'Verified successfully', token, user: existingUser });
+                        }
+                    }
+                    return res.status(500).json({ message: 'Failed to create account' });
+                }
             }
         }
     }

--- a/Backend/scripts/retry_pending_registrations.js
+++ b/Backend/scripts/retry_pending_registrations.js
@@ -5,12 +5,27 @@ import { sendMailWithRetry } from '../utils/mailer.js';
 
 async function run() {
   try {
-    if (typeof redisClient.keys !== 'function') {
-      console.warn('redisClient.keys not available; ensure REDIS_URL is set in production to run this script. Aborting.');
+    // Collect keys using SCAN where available to avoid blocking Redis on large datasets.
+    let keys = [];
+    const keyPattern = 'pending:registration:*';
+    if (typeof redisClient.scan === 'function') {
+      let cursor = '0';
+      do {
+        // ioredis returns [nextCursor, results]
+        const res = await redisClient.scan(cursor, 'MATCH', keyPattern, 'COUNT', 100);
+        const nextCursor = Array.isArray(res) ? res[0] : res.cursor;
+        const batch = Array.isArray(res) ? res[1] : res.keys;
+        if (Array.isArray(batch) && batch.length > 0) keys.push(...batch);
+        cursor = nextCursor;
+      } while (cursor !== '0');
+    } else if (typeof redisClient.keys === 'function') {
+      console.warn('redisClient.scan not available; falling back to KEYS (may block Redis on large datasets)');
+      keys = await redisClient.keys(keyPattern);
+    } else {
+      console.warn('redisClient.scan and keys not available; ensure REDIS_URL is set in production to run this script. Aborting.');
       process.exit(0);
     }
 
-    const keys = await redisClient.keys('pending:registration:*');
     if (!keys || keys.length === 0) {
       console.info('No pending registrations found');
       process.exit(0);
@@ -38,9 +53,45 @@ async function run() {
             text: `Welcome to ChatRaj!\n\nYour OTP is: ${pending.otp}\n\nPlease enter this code in the registration popup to activate your account.`,
           }, { retries: 3 });
 
+          // Update metadata while preserving original TTL where possible.
           pending.lastSentAt = Date.now();
           pending.sentCount = sentCount + 1;
-          await redisClient.set(k, JSON.stringify(pending), 'EX', ttlDefault);
+          const newVal = JSON.stringify(pending);
+
+          // Prefer GETSET which preserves TTL on Redis.
+          if (typeof redisClient.getset === 'function') {
+            try {
+              await redisClient.getset(k, newVal);
+            } catch (e) {
+              // fallback below
+              throw e;
+            }
+          } else {
+            // Fallback: read remaining TTL and restore it after set
+            let remainingMs = null;
+            if (typeof redisClient.pttl === 'function') {
+              try {
+                remainingMs = await redisClient.pttl(k);
+              } catch (e) { remainingMs = null; }
+            }
+            if (remainingMs == null && typeof redisClient.ttl === 'function') {
+              try {
+                const secs = await redisClient.ttl(k);
+                if (typeof secs === 'number' && secs >= 0) remainingMs = secs * 1000;
+              } catch (e) { remainingMs = null; }
+            }
+            if (remainingMs != null && remainingMs > 0) {
+              await redisClient.set(k, newVal);
+              if (typeof redisClient.pexpire === 'function') {
+                await redisClient.pexpire(k, remainingMs);
+              } else if (typeof redisClient.expire === 'function') {
+                await redisClient.expire(k, Math.ceil(remainingMs / 1000));
+              }
+            } else {
+              console.warn('Could not preserve TTL for', k, '; skipping metadata update to avoid extending OTP lifetime');
+            }
+          }
+
           console.info('Resent OTP to', pending.email);
         } catch (err) {
           console.error('Failed to resend to', pending.email, err && err.message ? err.message : err);


### PR DESCRIPTION
fix(redis/mailer): preserve TTL on resend, use SCAN in retry worker, flatten verify flow

## Summary by Sourcery

Ensure pending registration OTP flows in Redis preserve expiration while improving retry scanning and verification handling.

Bug Fixes:
- Preserve the original TTL of pending registration OTP keys when resending emails or updating metadata to avoid unintentionally extending OTP validity.
- Handle Redis access errors more safely during OTP verification and account creation from pending registrations.

Enhancements:
- Switch the retry worker for pending registrations from KEYS to SCAN to avoid blocking Redis on large datasets.
- Simplify and flatten the OTP verification flow for pending registrations, including clearer handling of duplicate-account races.