### PR TITLE
Fix the otp sending issue.

### DIFF
--- a/Backend/controllers/user.controller.js
+++ b/Backend/controllers/user.controller.js
@@ -135,15 +135,20 @@ export const createUserController = async (req, res) => {
                         latest.lastSentAt = Date.now();
                         latest.sentCount = (latest.sentCount || 0) + 1;
                         const newVal = JSON.stringify(latest);
-                        // Try to update without changing TTL using GETSET (preserves TTL)
+
+                        // Prefer GETSET which preserves TTL on Redis. If GETSET fails
+                        // fall through to TTL-preserving fallback rather than rethrowing.
+                        let updatedViaGetSet = false;
                         if (typeof redisClient.getset === 'function') {
                             try {
                                 await redisClient.getset(pendingKey, newVal);
+                                updatedViaGetSet = true;
                             } catch (e) {
-                                // fallback to pttl/ttl approach below
-                                throw e;
+                                console.warn('redis GETSET failed; falling back to TTL-preserving set:', e && e.message ? e.message : e);
                             }
-                        } else {
+                        }
+
+                        if (!updatedViaGetSet) {
                             // Fallback: attempt to read remaining TTL and restore it after set
                             let remainingMs = null;
                             if (typeof redisClient.pttl === 'function') {
@@ -252,7 +257,14 @@ export const verifyOtpController = async (req, res) => {
             }
 
             if (pendingJson) {
-                const pending = JSON.parse(pendingJson);
+                let pending;
+                try {
+                    pending = JSON.parse(pendingJson);
+                } catch (parseErr) {
+                    console.error('Failed to parse pending registration JSON for', pendingKey, parseErr && (parseErr.message || parseErr));
+                    return res.status(500).json({ message: 'Corrupt pending registration data' });
+                }
+
                 if (pending.otp !== otp) return res.status(401).json({ message: 'Invalid OTP' });
 
                 // Create the real user record from pending values.
@@ -324,9 +336,14 @@ export const adminGetOtpController = async (req, res) => {
                     const pendingKey = `pending:registration:${normalizedEmail}`;
                     const pendingJson = await redisClient.get(pendingKey);
                     if (pendingJson) {
-                        const pending = JSON.parse(pendingJson);
-                        // synthesize a minimal user-like object for masking
-                        user = { _id: null, email: normalizedEmail, otp: pending.otp };
+                        try {
+                            const pending = JSON.parse(pendingJson);
+                            // synthesize a minimal user-like object for masking
+                            user = { _id: null, email: normalizedEmail, otp: pending.otp };
+                        } catch (parseErr) {
+                            console.error('Failed to parse pending registration JSON for admin OTP:', parseErr && (parseErr.message || parseErr));
+                            return res.status(500).json({ message: 'Corrupt pending registration data' });
+                        }
                     }
                 } catch (redisErr) {
                     console.error('Failed to read pending registration for admin OTP:', redisErr && redisErr.message ? redisErr.message : redisErr);

--- a/Backend/scripts/retry_pending_registrations.js
+++ b/Backend/scripts/retry_pending_registrations.js
@@ -10,13 +10,29 @@ async function run() {
     const keyPattern = 'pending:registration:*';
     if (typeof redisClient.scan === 'function') {
       let cursor = '0';
+      let safety = 0;
       do {
-        // ioredis returns [nextCursor, results]
+        // ioredis typically returns [nextCursor, keys]
         const res = await redisClient.scan(cursor, 'MATCH', keyPattern, 'COUNT', 100);
-        const nextCursor = Array.isArray(res) ? res[0] : res.cursor;
-        const batch = Array.isArray(res) ? res[1] : res.keys;
+        let nextCursor;
+        let batch;
+        if (Array.isArray(res) && res.length >= 2) {
+          nextCursor = res[0];
+          batch = res[1];
+        } else if (res && typeof res === 'object' && ('cursor' in res) && Array.isArray(res.keys)) {
+          nextCursor = res.cursor;
+          batch = res.keys;
+        } else {
+          console.warn('Unexpected SCAN response shape; aborting scan to avoid silent failure:', res);
+          break;
+        }
         if (Array.isArray(batch) && batch.length > 0) keys.push(...batch);
-        cursor = nextCursor;
+        cursor = String(nextCursor);
+        // safety to avoid potential infinite loops in case of unexpected cursor behavior
+        if (++safety > 10000) {
+          console.warn('SCAN loop exceeded safety limit; aborting');
+          break;
+        }
       } while (cursor !== '0');
     } else if (typeof redisClient.keys === 'function') {
       console.warn('redisClient.scan not available; falling back to KEYS (may block Redis on large datasets)');
@@ -38,7 +54,14 @@ async function run() {
       try {
         const v = await redisClient.get(k);
         if (!v) continue;
-        const pending = JSON.parse(v);
+        let pending;
+        try {
+          pending = JSON.parse(v);
+        } catch (parseErr) {
+          console.error('Failed to parse pending registration JSON for key', k, parseErr && (parseErr.message || parseErr));
+          // Skip this key to avoid crashing the whole job
+          continue;
+        }
         const sentCount = Number(pending.sentCount || 0);
         if (sentCount >= maxAttempts) {
           console.info('Max attempts reached for', pending.email);
@@ -58,15 +81,19 @@ async function run() {
           pending.sentCount = sentCount + 1;
           const newVal = JSON.stringify(pending);
 
-          // Prefer GETSET which preserves TTL on Redis.
+          // Prefer GETSET which preserves TTL on Redis. If GETSET fails,
+          // log and fall back to TTL-preserving update instead of aborting.
+          let updatedViaGetSet = false;
           if (typeof redisClient.getset === 'function') {
             try {
               await redisClient.getset(k, newVal);
+              updatedViaGetSet = true;
             } catch (e) {
-              // fallback below
-              throw e;
+              console.warn('redis GETSET failed for', k, '— falling back to TTL-preserving set:', e && e.message ? e.message : e);
             }
-          } else {
+          }
+
+          if (!updatedViaGetSet) {
             // Fallback: read remaining TTL and restore it after set
             let remainingMs = null;
             if (typeof redisClient.pttl === 'function') {


### PR DESCRIPTION
Fix the otp sending issue.

## Summary by Sourcery

Improve robustness of pending registration OTP handling and Redis interactions to prevent silent failures and infinite loops.

Bug Fixes:
- Prevent infinite or stuck Redis SCAN loops when retrying pending registrations by validating responses and enforcing a safety limit.
- Avoid crashes when pending registration data in Redis is malformed by safely handling JSON parse errors across OTP retry, verification, and admin retrieval flows.
- Ensure OTP resend flows continue working even if Redis GETSET fails by falling back to TTL-preserving update logic instead of throwing.

Enhancements:
- Add defensive logging around unexpected Redis SCAN and GETSET behaviors to aid in diagnosing OTP-related issues.