### PR TITLE
Add theme toggle animation

### DIFF
--- a/frontend/src/screens/Home.jsx
+++ b/frontend/src/screens/Home.jsx
@@ -144,6 +144,8 @@ const Home = () => {
   const [lastScrollY, setLastScrollY] = useState(0);
   const [showFabMenu, setShowFabMenu] = useState(false);
   const [showAskChatRajModal, setShowAskChatRajModal] = useState(false);
+  const [isAnimatingTheme, setIsAnimatingTheme] = useState(false);
+  const [themeOverlayColor, setThemeOverlayColor] = useState('#ffffff');
 
 
   useEffect(() => {
@@ -174,6 +176,16 @@ const Home = () => {
     }
   };
 
+  const handleThemeToggle = () => {
+    if (isAnimatingTheme) return;
+    setThemeOverlayColor(isDarkMode ? '#f3f4f6' : '#111827');
+    setIsAnimatingTheme(true);
+    setTimeout(() => {
+      setIsDarkMode(!isDarkMode);
+      setIsAnimatingTheme(false);
+    }, 750); // Swap theme exactly halfway through the 1.5s animation and trigger exit animation
+  };
+
   const AnimatedBg = () => (
     <div className="absolute inset-0 z-0 overflow-hidden pointer-events-none">
       <motion.div
@@ -202,6 +214,30 @@ const Home = () => {
 
   return (
     <div className="flex flex-col min-h-screen overflow-x-hidden bg-transparent">
+      <AnimatePresence>
+        {isAnimatingTheme && (
+          <motion.div
+            initial={{ clipPath: 'circle(0% at calc(100% - 40px) 40px)', opacity: 1 }}
+            animate={{ clipPath: 'circle(150% at calc(100% - 40px) 40px)', opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{
+              duration: 0.75,
+              ease: 'easeInOut'
+            }}
+            style={{
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              zIndex: 9999, // Extremely high z-index to cover everything
+              backgroundColor: themeOverlayColor, // Target background color based on what it will become
+              pointerEvents: 'auto', // Block interactions during animation
+            }}
+          />
+        )}
+      </AnimatePresence>
+
       <LiquidCursor />
       {typeof window !== "undefined" && !window.matchMedia('(prefers-reduced-motion: reduce)').matches && (
         <AnimatedBg />
@@ -244,7 +280,7 @@ const Home = () => {
             Try ChatRaj
           </button>
           <button
-            onClick={() => setIsDarkMode(!isDarkMode)}
+            onClick={handleThemeToggle}
             className={`p-2 transition-colors rounded-lg ${isDarkMode ? 'text-gray-300 hover:text-blue-400' : 'text-gray-600 hover:text-blue-600'}`}
           >
             <i className={`text-xl ${isDarkMode ? 'ri-sun-line' : 'ri-moon-line'}`}></i>


### PR DESCRIPTION
Implemented a 1.5-second full-screen animation (circular reveal) for theme switching on the home page as requested by the user, ensuring interactions are blocked during the transition and no other code is modified.

---
*PR created automatically by Jules for task [7391635550017514532](https://jules.google.com/task/7391635550017514532) started by @Abhirajgautam28*

## Summary by Sourcery

New Features:
- Introduce a circular full-screen theme transition overlay on the home page when toggling dark mode.