### PR TITLE
feat(frontend): Implement liquid swipe theme transition on Home

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -244,6 +244,56 @@ button {
   }
 }
 
+/* Liquid Swipe View Transition specifically for Home Screen */
+.theme-transition-liquid::view-transition-group(root) {
+  animation-duration: var(--theme-transition-duration);
+}
+
+.theme-transition-liquid::view-transition-old(root) {
+  animation: liquid-exit var(--theme-transition-duration) cubic-bezier(0.87, 0, 0.13, 1) forwards;
+  z-index: 1;
+}
+
+.theme-transition-liquid::view-transition-new(root) {
+  animation: liquid-enter var(--theme-transition-duration) cubic-bezier(0.87, 0, 0.13, 1) forwards;
+  z-index: 2;
+}
+
+@keyframes liquid-exit {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+    clip-path: polygon(100% 0, 100% 100%, 0 100%, 0 0);
+  }
+  100% {
+    opacity: 0.5;
+    transform: scale(0.9);
+    clip-path: polygon(100% 0, 100% 100%, 0 100%, 0 0);
+  }
+}
+
+@keyframes liquid-enter {
+  0% {
+    opacity: 1;
+    transform: scale(1.05);
+    clip-path: polygon(100% 0, 100% 0, 100% 100%, 100% 100%);
+  }
+  20% {
+    clip-path: polygon(100% 0, 80% 15%, 85% 85%, 100% 100%);
+  }
+  40% {
+    clip-path: polygon(100% 0, 50% 30%, 60% 70%, 100% 100%);
+  }
+  60% {
+    clip-path: polygon(100% 0, 20% 50%, 30% 90%, 100% 100%);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+    clip-path: polygon(100% 0, 0 0, 0 100%, 100% 100%);
+  }
+}
+
 /* Fallback for browsers that do not support View Transitions */
 .theme-transitioning,
 .theme-transitioning * {

--- a/frontend/src/screens/Home.jsx
+++ b/frontend/src/screens/Home.jsx
@@ -179,7 +179,7 @@ const Home = () => {
   const handleThemeToggle = () => {
     executeThemeTransition(() => {
       setIsDarkMode((prev) => !prev);
-    }, shouldReduceMotion);
+    }, shouldReduceMotion, true); // true indicating this is the Home screen for the liquid effect
   };
 
   const AnimatedBg = () => (

--- a/frontend/src/utils/themeTransition.js
+++ b/frontend/src/utils/themeTransition.js
@@ -7,7 +7,7 @@ import { flushSync } from 'react-dom';
  * @param {Function} updateStateCallback - The state setter to execute (e.g. setIsDarkMode)
  * @param {boolean} shouldReduceMotion - Whether the user prefers reduced motion (bypasses animation)
  */
-export const executeThemeTransition = (updateStateCallback, shouldReduceMotion = false) => {
+export const executeThemeTransition = (updateStateCallback, shouldReduceMotion = false, isHome = false) => {
   if (shouldReduceMotion || typeof document === 'undefined') {
     updateStateCallback();
     return;
@@ -30,7 +30,9 @@ export const executeThemeTransition = (updateStateCallback, shouldReduceMotion =
     return;
   }
 
-  document.documentElement.classList.add('theme-transition');
+  const transitionClass = isHome ? 'theme-transition-liquid' : 'theme-transition';
+
+  document.documentElement.classList.add(transitionClass);
 
   const transition = document.startViewTransition(() => {
     flushSync(() => {
@@ -39,6 +41,6 @@ export const executeThemeTransition = (updateStateCallback, shouldReduceMotion =
   });
 
   transition.finished.finally(() => {
-    document.documentElement.classList.remove('theme-transition');
+    document.documentElement.classList.remove(transitionClass);
   });
 };


### PR DESCRIPTION
- Engineered a custom, home-screen exclusive "liquid swipe" theme transition using a dynamic `clip-path` polygon animation.
- Updated `executeThemeTransition` utility to accept an `isHome` flag, seamlessly routing the Home toggle to `.theme-transition-liquid` while preserving the 3D Warp effect globally across all other routes.
- Confirmed resolution of the stale `ReferenceError` concerning `setIsDarkMode` on the homepage toggle button.

## Summary by Sourcery

Implement a home-screen-specific liquid swipe theme transition while preserving the existing global theme transition behavior.

New Features:
- Add a liquid swipe view transition animation for the Home screen theme toggle using a custom clip-path animation.

Enhancements:
- Extend the theme transition utility to support a home-specific transition mode via an additional flag parameter.
- Wire the Home screen theme toggle to use the new liquid transition while keeping the existing 3D warp transition for other routes.