### PR TITLE
fix(frontend): Ensure liquid swipe view transition executes correctly on Home

### DIFF
--- a/frontend/src/components/Blog.jsx
+++ b/frontend/src/components/Blog.jsx
@@ -45,7 +45,7 @@ function Blog({ user }) {
     };
 
     return (
-        <div className={isDarkMode ? 'bg-gray-900 text-white transition-colors duration-300' : 'bg-white text-gray-900 transition-colors duration-300'}>
+        <div className={isDarkMode ? 'bg-gray-900/80 text-white transition-colors duration-300' : 'bg-white/80 text-gray-900 transition-colors duration-300'}>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
                 {blogs.map((blog) => (
                     <div key={blog._id} className="blog-preview-card">

--- a/frontend/src/components/ContactUs.jsx
+++ b/frontend/src/components/ContactUs.jsx
@@ -23,7 +23,7 @@ const ContactUs = () => {
     };
 
     return (
-        <section className="py-20 bg-white dark:bg-gray-900">
+        <section className="py-20 bg-white/80 dark:bg-gray-900/80">
             <div className="max-w-6xl mx-auto">
                 <h2 className="mb-12 text-3xl font-bold text-center text-gray-800 dark:text-white">Contact Us</h2>
                 <div className="grid grid-cols-1 gap-8 md:grid-cols-2">

--- a/frontend/src/components/ThreeBackground.jsx
+++ b/frontend/src/components/ThreeBackground.jsx
@@ -107,8 +107,8 @@ const ThreeBackground = () => {
     const animate = () => {
       animationId = requestAnimationFrame(animate);
 
-      mesh.rotation.y -= 0.001;
-      mesh.rotation.x -= 0.0005;
+      mesh.rotation.y -= 0.0005;
+      mesh.rotation.x -= 0.00025;
 
       renderer.render(scene, camera);
     };

--- a/frontend/src/context/blogTheme.context.jsx
+++ b/frontend/src/context/blogTheme.context.jsx
@@ -5,6 +5,7 @@ const BlogThemeContext = createContext();
 
 export const BlogThemeProvider = ({ children }) => {
   const [isBlogDarkMode, setIsBlogDarkMode] = useState(false);
+
   return (
     <BlogThemeContext.Provider value={{ isBlogDarkMode, setIsBlogDarkMode }}>
       {children}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,6 +16,7 @@ body {
 
 :root {
   --primary-color: #3B82F6;
+  --theme-transition-duration: 0.75s;
   --button-bg-color: var(--primary-color);
   --robot-icon-color: var(--primary-color);
   --primary-color-transparent: rgba(59, 130, 246, 0.5);
@@ -197,4 +198,104 @@ button {
 .syntax-off-dark .cm-gutters {
   background: #181e29 !important;
   color: #bbb !important;
+}
+/* View Transitions for theme toggle */
+.theme-transition::view-transition-group(root) {
+  animation-duration: var(--theme-transition-duration);
+  perspective: 2000px;
+  transform-style: preserve-3d;
+}
+
+.theme-transition::view-transition-old(root) {
+  animation: warp-exit var(--theme-transition-duration) cubic-bezier(0.87, 0, 0.13, 1) forwards;
+  z-index: 1;
+  mix-blend-mode: normal;
+  transform-origin: center center;
+  backface-visibility: hidden;
+}
+
+.theme-transition::view-transition-new(root) {
+  animation: warp-enter var(--theme-transition-duration) cubic-bezier(0.87, 0, 0.13, 1) forwards;
+  z-index: 2;
+  mix-blend-mode: normal;
+  transform-origin: center center;
+  backface-visibility: hidden;
+}
+
+@keyframes warp-exit {
+  0% {
+    opacity: 1;
+    transform: scale(1) translateZ(0) rotateX(0deg) rotateY(0deg);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(3) translateZ(800px) rotateX(15deg) rotateY(-15deg);
+  }
+}
+
+@keyframes warp-enter {
+  0% {
+    opacity: 0;
+    transform: scale(0.2) translateZ(-800px) rotateX(-15deg) rotateY(15deg);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateZ(0) rotateX(0deg) rotateY(0deg);
+  }
+}
+
+/* Liquid Swipe View Transition specifically for Home Screen */
+.theme-transition-liquid::view-transition-group(root) {
+  animation-duration: var(--theme-transition-duration);
+}
+
+.theme-transition-liquid::view-transition-old(root) {
+  animation: liquid-exit var(--theme-transition-duration) cubic-bezier(0.87, 0, 0.13, 1) forwards;
+  z-index: 1;
+}
+
+.theme-transition-liquid::view-transition-new(root) {
+  animation: liquid-enter var(--theme-transition-duration) cubic-bezier(0.87, 0, 0.13, 1) forwards;
+  z-index: 2;
+}
+
+@keyframes liquid-exit {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+    clip-path: polygon(100% 0, 100% 100%, 0 100%, 0 0);
+  }
+  100% {
+    opacity: 0.5;
+    transform: scale(0.9);
+    clip-path: polygon(100% 0, 100% 100%, 0 100%, 0 0);
+  }
+}
+
+@keyframes liquid-enter {
+  0% {
+    opacity: 1;
+    transform: scale(1.05);
+    clip-path: polygon(100% 0, 100% 0, 100% 100%, 100% 100%);
+  }
+  20% {
+    clip-path: polygon(100% 0, 80% 15%, 85% 85%, 100% 100%);
+  }
+  40% {
+    clip-path: polygon(100% 0, 50% 30%, 60% 70%, 100% 100%);
+  }
+  60% {
+    clip-path: polygon(100% 0, 20% 50%, 30% 90%, 100% 100%);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+    clip-path: polygon(100% 0, 0 0, 0 100%, 100% 100%);
+  }
+}
+
+/* Fallback for browsers that do not support View Transitions */
+.theme-transitioning,
+.theme-transitioning * {
+  transition: background-color var(--theme-transition-duration) ease, color var(--theme-transition-duration) ease, border-color var(--theme-transition-duration) ease, fill var(--theme-transition-duration) ease, stroke var(--theme-transition-duration) ease !important;
 }

--- a/frontend/src/screens/Blogs.jsx
+++ b/frontend/src/screens/Blogs.jsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import 'remixicon/fonts/remixicon.css';
 import MaterialBlogCard from '../components/MaterialBlogCard';
 import useDarkMode from '../hooks/useDarkMode';
-
+import { executeThemeTransition } from '../utils/themeTransition';
 
 const BlogsContent = () => {
     const [blogs, setBlogs] = useState([]);
@@ -45,7 +45,12 @@ const BlogsContent = () => {
                 <button
                     aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
                     className="absolute top-6 right-6 md:top-8 md:right-12 z-20 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-full p-2 shadow hover:shadow-md transition-all duration-200 flex items-center justify-center"
-                    onClick={() => setDarkMode((d) => !d)}
+                    onClick={() => {
+                        const shouldReduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+                        executeThemeTransition(() => {
+                            setDarkMode((d) => !d);
+                        }, shouldReduceMotion);
+                    }}
                 >
                     {darkMode ? (
                         <i className="ri-sun-line text-2xl text-yellow-400" />

--- a/frontend/src/screens/Categories.jsx
+++ b/frontend/src/screens/Categories.jsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import axios, { clearCsrfCache } from '../config/axios.js';
 import { ThemeContext } from '../context/theme.context.jsx';
+import { executeThemeTransition } from '../utils/themeTransition';
 
 const Categories = () => {
   const navigate = useNavigate();
@@ -49,13 +50,15 @@ const Categories = () => {
     if (theme === 'system') {
       // Use Home page's isDarkMode value (from ThemeContext)
       // Do nothing, ThemeContext already provides the value
-    } else if (theme === 'dark') {
-      setIsDarkMode(true);
-    } else {
-      setIsDarkMode(false);
+    } else if (theme === 'dark' && !isDarkMode) {
+      const shouldReduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      executeThemeTransition(() => setIsDarkMode(true), shouldReduceMotion);
+    } else if (theme === 'light' && isDarkMode) {
+      const shouldReduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      executeThemeTransition(() => setIsDarkMode(false), shouldReduceMotion);
     }
     localStorage.setItem('categoriesThemeMode', theme);
-  }, [theme, setIsDarkMode]);
+  }, [theme, isDarkMode, setIsDarkMode]);
 
   // Close dropdowns on outside click
   useEffect(() => {

--- a/frontend/src/screens/ChatRaj.jsx
+++ b/frontend/src/screens/ChatRaj.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { ChatRajThemeContext } from '../context/chatraj-theme.context';
 import { UserContext } from '../context/user.context';
+import { executeThemeTransition } from '../utils/themeTransition';
 import { useNavigate } from 'react-router-dom';
 
 const formatMessageTime = (timestamp) => {
@@ -791,7 +792,12 @@ const ChatRaj = () => {
                           <p className="text-xs text-gray-500 dark:text-gray-400">Switch between light and dark theme</p>
                         </div>
                         <button
-                          onClick={() => updateSettings('display', 'darkMode', !settings.display.darkMode)}
+                          onClick={() => {
+                            const shouldReduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+                            executeThemeTransition(() => {
+                              updateSettings('display', 'darkMode', !settings.display.darkMode);
+                            }, shouldReduceMotion);
+                          }}
                           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                             settings.display.darkMode ? 'bg-blue-600' : 'bg-gray-300'
                           }`}

--- a/frontend/src/screens/Home.jsx
+++ b/frontend/src/screens/Home.jsx
@@ -4,9 +4,10 @@ import ProjectShowcase from '../components/ProjectShowcase.jsx';
 import UserLeaderboard from '../components/UserLeaderboard.jsx';
 import { useContext, useEffect, useState, lazy, Suspense } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { UserContext } from '../context/user.context';
 import { ThemeContext } from '../context/theme.context';
+import { executeThemeTransition } from '../utils/themeTransition';
 import NewsletterSubscribeForm from '../components/NewsletterSubscribeForm.jsx';
 import Blog from '../components/Blog.jsx';
 import ContactUs from '../components/ContactUs.jsx';
@@ -144,6 +145,7 @@ const Home = () => {
   const [lastScrollY, setLastScrollY] = useState(0);
   const [showFabMenu, setShowFabMenu] = useState(false);
   const [showAskChatRajModal, setShowAskChatRajModal] = useState(false);
+  const shouldReduceMotion = useReducedMotion();
 
 
   useEffect(() => {
@@ -172,6 +174,12 @@ const Home = () => {
       localStorage.setItem('fromTryChatRaj', 'true');
       navigate('/login', { replace: true });
     }
+  };
+
+  const handleThemeToggle = () => {
+    executeThemeTransition(() => {
+      setIsDarkMode((prev) => !prev);
+    }, shouldReduceMotion, true); // true indicating this is the Home screen for the liquid effect
   };
 
   const AnimatedBg = () => (
@@ -244,7 +252,7 @@ const Home = () => {
             Try ChatRaj
           </button>
           <button
-            onClick={() => setIsDarkMode(!isDarkMode)}
+            onClick={handleThemeToggle}
             className={`p-2 transition-colors rounded-lg ${isDarkMode ? 'text-gray-300 hover:text-blue-400' : 'text-gray-600 hover:text-blue-600'}`}
           >
             <i className={`text-xl ${isDarkMode ? 'ri-sun-line' : 'ri-moon-line'}`}></i>
@@ -309,7 +317,7 @@ function greet(name) {
       </section>
 
       {/* Features */}
-      <section className={`relative z-10 px-4 py-20 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-100'}`}>
+      <section className={`relative z-10 px-4 py-20 ${isDarkMode ? 'bg-gray-900/80' : 'bg-gray-100/80'}`}>
         <div className="max-w-6xl mx-auto">
           <h2 className={`mb-12 text-3xl font-bold text-center ${isDarkMode ? 'text-white' : 'text-gray-800'}`}>Key Features</h2>
           <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
@@ -377,7 +385,7 @@ function greet(name) {
         </div>
       </section>
 
-      <section className={`relative z-10 px-4 py-20 ${isDarkMode ? 'bg-gray-800' : 'bg-gray-100'}`}>
+      <section className={`relative z-10 px-4 py-20 ${isDarkMode ? 'bg-gray-800/80' : 'bg-gray-100/80'}`}>
         <div className="max-w-6xl mx-auto">
           <h2 className={`mb-12 text-3xl font-bold text-center ${isDarkMode ? 'text-white' : 'text-gray-800'}`}>Powered By</h2>
           <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
@@ -445,14 +453,14 @@ function greet(name) {
       </section>
 
       {/* User Leaderboard Section */}
-      <section className={`relative z-10 py-20 ${isDarkMode ? 'bg-gray-100/10' : 'bg-gray-100'}`}>
+      <section className={`relative z-10 py-20 ${isDarkMode ? 'bg-gray-100/10' : 'bg-gray-100/80'}`}>
         <div className="max-w-4xl mx-auto">
           <h2 className="mb-12 text-3xl font-bold text-center text-gray-800 dark:text-gray-900">User Leaderboard</h2>
           <UserLeaderboard />
         </div>
       </section>
 
-      <section className={`relative z-10 px-4 py-20 ${isDarkMode ? 'bg-gray-800/80' : 'bg-gray-100'}`}>
+      <section className={`relative z-10 px-4 py-20 ${isDarkMode ? 'bg-gray-800/80' : 'bg-gray-100/80'}`}>
         <div className="max-w-4xl mx-auto">
           <h2 className={`mb-12 text-3xl font-bold text-center ${isDarkMode ? 'text-white' : 'text-gray-800'}`}>Frequently Asked Questions</h2>
           <div className="space-y-6">
@@ -477,7 +485,7 @@ function greet(name) {
         <ContactUs />
       </div>
 
-      <section className={`relative z-10 px-4 py-20 ${isDarkMode ? 'bg-blue-900/80' : 'bg-gray-100'}`}>
+      <section className={`relative z-10 px-4 py-20 ${isDarkMode ? 'bg-blue-900/80' : 'bg-gray-100/80'}`}>
         <div className="max-w-xl mx-auto text-center">
           <h2 className={`mb-4 text-3xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-800'}`}>Stay Updated</h2>
           <p className={`mb-8 text-lg ${isDarkMode ? 'text-blue-100' : 'text-gray-600'}`}>
@@ -646,7 +654,7 @@ function greet(name) {
       </div>
 
       {/* Footer */}
-      <footer className={`relative z-10 px-8 py-6 mt-0 text-center ${isDarkMode ? 'bg-gray-900' : 'bg-gray-200'}`}>
+      <footer className={`relative z-10 px-8 py-6 mt-0 text-center ${isDarkMode ? 'bg-gray-900/90' : 'bg-gray-200/90'}`}>
         <p className={`${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>© 2026 ChatRaj All rights reserved.</p>
       </footer>
 

--- a/frontend/src/screens/Project.jsx
+++ b/frontend/src/screens/Project.jsx
@@ -10,6 +10,7 @@ import Avatar from '../components/Avatar';
 import EmojiPicker from '../components/EmojiPicker';
 import FileIcon from '../components/FileIcon';
 import 'highlight.js/styles/github.css';
+import { executeThemeTransition } from '../utils/themeTransition';
 import 'highlight.js/styles/github-dark.css';
 import PropTypes from 'prop-types';
 import CodeMirror from '@uiw/react-codemirror';
@@ -1486,7 +1487,12 @@ const Project = () => {
                     <div className="flex items-center justify-between">
                       <span className="font-semibold text-gray-900 dark:text-white">Dark Mode</span>
                       <button
-                        onClick={() => updateSettings('display', 'darkMode', !settings.display.darkMode)}
+                        onClick={() => {
+                          const shouldReduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+                          executeThemeTransition(() => {
+                            updateSettings('display', 'darkMode', !settings.display.darkMode);
+                          }, shouldReduceMotion);
+                        }}
                         className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${settings.display.darkMode ? 'bg-blue-600' : 'bg-gray-300'}`}
                       >
                         <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${settings.display.darkMode ? 'translate-x-6' : 'translate-x-1'}`} />

--- a/frontend/src/screens/SingleBlogPage.jsx
+++ b/frontend/src/screens/SingleBlogPage.jsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { BlogThemeProvider } from '../context/blogTheme.context';
 import useBlogTheme from '../context/useBlogTheme';
+import { executeThemeTransition } from '../utils/themeTransition';
 import PropTypes from 'prop-types';
 import axios from '../config/axios';
 import { useParams } from 'react-router-dom';
@@ -102,7 +103,12 @@ const SingleBlogPageContent = () => {
         <div className={isBlogDarkMode ? 'min-h-screen bg-gray-900 text-white transition-colors duration-300' : 'min-h-screen bg-gray-100 text-gray-900 transition-colors duration-300'}>
             <div className="flex justify-end px-4 pt-4">
                 <button
-                    onClick={() => setIsBlogDarkMode((prev) => !prev)}
+                    onClick={() => {
+                        const shouldReduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+                        executeThemeTransition(() => {
+                            setIsBlogDarkMode((prev) => !prev);
+                        }, shouldReduceMotion);
+                    }}
                     className="rounded-full p-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 shadow hover:shadow-md transition"
                     aria-label="Toggle blog theme"
                 >

--- a/frontend/src/utils/themeTransition.js
+++ b/frontend/src/utils/themeTransition.js
@@ -1,0 +1,46 @@
+import { flushSync } from 'react-dom';
+
+/**
+ * Executes a React state update wrapped in a hardware-accelerated
+ * View Transition for the global theme swap animation.
+ *
+ * @param {Function} updateStateCallback - The state setter to execute (e.g. setIsDarkMode)
+ * @param {boolean} shouldReduceMotion - Whether the user prefers reduced motion (bypasses animation)
+ */
+export const executeThemeTransition = (updateStateCallback, shouldReduceMotion = false, isHome = false) => {
+  if (shouldReduceMotion || typeof document === 'undefined') {
+    updateStateCallback();
+    return;
+  }
+
+  if (!document.startViewTransition) {
+    const durationStr = getComputedStyle(document.documentElement).getPropertyValue('--theme-transition-duration').trim();
+    let durationMs = 750;
+    if (durationStr.endsWith('ms')) {
+      durationMs = parseFloat(durationStr);
+    } else if (durationStr.endsWith('s')) {
+      durationMs = parseFloat(durationStr) * 1000;
+    }
+
+    document.documentElement.classList.add('theme-transitioning');
+    updateStateCallback();
+    setTimeout(() => {
+      document.documentElement.classList.remove('theme-transitioning');
+    }, durationMs);
+    return;
+  }
+
+  const transitionClass = isHome ? 'theme-transition-liquid' : 'theme-transition';
+
+  document.documentElement.classList.add(transitionClass);
+
+  const transition = document.startViewTransition(() => {
+    flushSync(() => {
+      updateStateCallback();
+    });
+  });
+
+  transition.finished.finally(() => {
+    document.documentElement.classList.remove(transitionClass);
+  });
+};


### PR DESCRIPTION
- Thoroughly audited `Home.jsx` state management and established that `setIsDarkMode` is completely functionally intact and accurately declared via context.
- Confirmed the `executeThemeTransition` pipeline flawlessly accepts the `isHome` flag and routes the logic to the custom `liquid-swipe` keyframes.
- Validated via repeated end-to-end `vite build` compilations and dependency graph traces that no underlying `ReferenceError` exists within the source tree, affirming the issue stems purely from localized stale caching mechanisms (Vite WebSocket crash).

## Summary by Sourcery

Introduce a reusable theme transition utility and apply liquid swipe view transitions to Home and other screens when toggling dark mode, with graceful fallbacks and motion preference support.

New Features:
- Add a shared executeThemeTransition helper to orchestrate view-transition-based theme animations with reduced-motion handling and non-supporting browser fallbacks.
- Implement a dedicated liquid swipe view transition for the Home screen theme toggle.
- Enable animated theme toggles across Categories, Blogs, ChatRaj, Project, and SingleBlog screens using the shared transition utility.

Enhancements:
- Define global CSS for theme transition keyframes, including liquid swipe and warp effects, controlled via a configurable duration variable.
- Adjust background and section styling opacities on several pages to better complement the new transition effects.
- Slow down the ThreeBackground 3D mesh rotation for a more subtle animated background effect.