### PR TITLE
HEAD is now at c99406d fix(security): never expose OTP in responses unless explicitly allowed; default safe behavior

### DIFF
--- a/Backend/utils/mailer.js
+++ b/Backend/utils/mailer.js
@@ -274,4 +274,3 @@ export async function sendMailWithRetry(mailOptions, opts = {}) {
 export default {
   sendMailWithRetry,
 };
- 


### PR DESCRIPTION
HEAD is now at c99406d fix(security): never expose OTP in responses unless explicitly allowed; default safe behavior

## Summary by Sourcery

Enhancements:
- Normalize the export block formatting in the mailer utility to remove an unnecessary trailing line.