### PR TITLE
chore: refactor crypto import in security utils to use named imports

### DIFF
--- a/Backend/utils/security.js
+++ b/Backend/utils/security.js
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import { createHmac, timingSafeEqual, randomBytes } from 'node:crypto';
 
 // CSRF signing secret used for stateless signed tokens (fallback for cross-origin clients)
 const CSRF_SIGNING_SECRET = (() => {
@@ -10,7 +10,7 @@ const CSRF_SIGNING_SECRET = (() => {
 })();
 
 export function signRawToken(raw) {
-  return `${raw}.${crypto.createHmac('sha256', CSRF_SIGNING_SECRET).update(raw).digest('base64url')}`;
+  return `${raw}.${createHmac('sha256', CSRF_SIGNING_SECRET).update(raw).digest('base64url')}`;
 }
 
 export function verifySignedCsrfToken(signed) {
@@ -19,11 +19,11 @@ export function verifySignedCsrfToken(signed) {
     const parts = signed.split('.');
     if (parts.length !== 2) return false;
     const [raw, sig] = parts;
-    const expected = crypto.createHmac('sha256', CSRF_SIGNING_SECRET).update(raw).digest('base64url');
+    const expected = createHmac('sha256', CSRF_SIGNING_SECRET).update(raw).digest('base64url');
     const a = Buffer.from(sig);
     const b = Buffer.from(expected);
     if (a.length !== b.length) return false;
-    if (!crypto.timingSafeEqual(a, b)) return false;
+    if (!timingSafeEqual(a, b)) return false;
     const idx = raw.indexOf(':');
     if (idx === -1) return false;
     const ts = Number(raw.slice(0, idx));
@@ -37,7 +37,7 @@ export function verifySignedCsrfToken(signed) {
 }
 
 export function createSignedCsrf() {
-  const raw = `${Date.now()}:${crypto.randomBytes(12).toString('base64url')}`;
+  const raw = `${Date.now()}:${randomBytes(12).toString('base64url')}`;
   return signRawToken(raw);
 }
 


### PR DESCRIPTION
Refactored `Backend/utils/security.js` to use named imports from `node:crypto` instead of a default `crypto` import. This resolves the "Unused Import: crypto" issue by removing the default identifier that was being flagged as unused, while following modern Node.js best practices for built-in modules.

Verified functionality with a smoke test ensuring HMAC signing, timing-safe equality, and random byte generation still work correctly.

# Pull Request

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

Fixes #(issue)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [ ] My code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

_Please add screenshots to help explain your changes._

## Additional context

_Add any other context about the pull request here._

## Summary by Sourcery

Enhancements:
- Update security utilities to import only the required crypto functions (HMAC, timing-safe equality, and random byte generation) via named imports from the built-in node:crypto module.