### PR TITLE
Add Legal Compliance Modals and Checkbox

### DIFF
--- a/frontend/src/components/PrivacyModal.jsx
+++ b/frontend/src/components/PrivacyModal.jsx
@@ -1,0 +1,65 @@
+import React, { useContext } from 'react';
+import BaseModal from './BaseModal.jsx';
+import { ThemeContext } from '../context/theme.context';
+import { getThemeClasses } from '../utils/themeClasses.js';
+
+const PrivacyModal = ({ isOpen, onRequestClose }) => {
+    const { isDarkMode, uiTheme } = useContext(ThemeContext) || {};
+    const themeStyle = getThemeClasses(uiTheme, isDarkMode);
+
+    return (
+        <BaseModal isOpen={isOpen} onRequestClose={onRequestClose} title="Privacy Policy" widthClass="max-w-3xl">
+            <div className={`space-y-4 ${themeStyle.textMain}`}>
+                <p><strong>Effective Date:</strong> January 1, 2026</p>
+
+                <p>Welcome to ChatRaj. We value your privacy and are committed to protecting your personal data. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our platform, strictly adhering to the requirements of India's Digital Personal Data Protection (DPDP) Act 2026.</p>
+
+                <h3 className="text-lg font-bold">1. Data Collection and Purpose Limitation</h3>
+                <p>We collect personal data only when it is strictly necessary to provide and improve our Services. The data we collect includes:</p>
+                <ul className="list-disc list-inside ml-4">
+                    <li><strong>Account Information:</strong> Name, email address, and encrypted passwords.</li>
+                    <li><strong>Usage Data:</strong> Information about how you interact with the platform, project metadata, and collaborative activities.</li>
+                    <li><strong>Technical Data:</strong> IP addresses, browser types, and device identifiers.</li>
+                </ul>
+                <p>Your data is processed exclusively for the purpose of operating the ChatRaj platform, authenticating users, providing AI suggestions, and ensuring security.</p>
+
+                <h3 className="text-lg font-bold">2. Consent Management (DPDP Act 2026 Compliance)</h3>
+                <p>Under the DPDP Act 2026, you have the right to control your personal data. We require explicit, clear, and specific consent before processing your information.</p>
+                <ul className="list-disc list-inside ml-4">
+                    <li><strong>Notice:</strong> We provide clear notice of the personal data collected and its purpose.</li>
+                    <li><strong>Right to Withdraw:</strong> You may withdraw your consent at any time by deleting your account or contacting our Data Protection Officer.</li>
+                </ul>
+
+                <h3 className="text-lg font-bold">3. Data Fiduciary Obligations</h3>
+                <p>As a Data Fiduciary under the DPDP Act 2026, ChatRaj implements robust security practices:</p>
+                <ul className="list-disc list-inside ml-4">
+                    <li>Encryption of data in transit and at rest.</li>
+                    <li>Strict access controls and rate limiting to prevent unauthorized access.</li>
+                    <li>Regular security audits and vulnerability assessments.</li>
+                </ul>
+
+                <h3 className="text-lg font-bold">4. Data Principal Rights</h3>
+                <p>You, as a Data Principal, possess the following rights:</p>
+                <ul className="list-disc list-inside ml-4">
+                    <li><strong>Right to Access:</strong> Request a summary of the personal data we hold about you.</li>
+                    <li><strong>Right to Correction:</strong> Request updates or corrections to inaccurate data.</li>
+                    <li><strong>Right to Erasure (Right to be Forgotten):</strong> Request the deletion of your personal data when it is no longer necessary for its original purpose or if you withdraw consent.</li>
+                    <li><strong>Right to Grievance Redressal:</strong> Register complaints regarding data processing practices.</li>
+                </ul>
+
+                <h3 className="text-lg font-bold">5. Data Sharing and Third Parties</h3>
+                <p>We do not sell your personal data. We may share data with trusted third-party Data Processors (e.g., hosting providers, Google Generative AI for code completion) strictly under contractual agreements that ensure they comply with the DPDP Act 2026 and protect your data.</p>
+
+                <h3 className="text-lg font-bold">6. Data Localization and Retention</h3>
+                <p>Your data is stored securely. We retain personal data only for as long as necessary to fulfill the purposes outlined in this policy or as required by law. Once the purpose is fulfilled, data is securely anonymized or deleted.</p>
+
+                <h3 className="text-lg font-bold">7. Changes to this Policy</h3>
+                <p>We may update this Privacy Policy periodically to reflect changes in our practices or legal requirements. Material changes will be communicated to you via the platform.</p>
+
+                <p className="mt-6">If you have any questions or wish to exercise your rights under the DPDP Act 2026, please contact our Data Protection Officer via the platform's support channels.</p>
+            </div>
+        </BaseModal>
+    );
+};
+
+export default PrivacyModal;

--- a/frontend/src/components/TermsModal.jsx
+++ b/frontend/src/components/TermsModal.jsx
@@ -1,0 +1,61 @@
+import React, { useContext } from 'react';
+import BaseModal from './BaseModal.jsx';
+import { ThemeContext } from '../context/theme.context';
+import { getThemeClasses } from '../utils/themeClasses.js';
+
+const TermsModal = ({ isOpen, onRequestClose }) => {
+    const { isDarkMode, uiTheme } = useContext(ThemeContext) || {};
+    const themeStyle = getThemeClasses(uiTheme, isDarkMode);
+
+    return (
+        <BaseModal isOpen={isOpen} onRequestClose={onRequestClose} title="Terms of Service" widthClass="max-w-3xl">
+            <div className={`space-y-4 ${themeStyle.textMain}`}>
+                <p><strong>Effective Date:</strong> January 1, 2026</p>
+
+                <p>Welcome to ChatRaj. These Terms of Service ("Terms") govern your use of the ChatRaj platform, website, and associated services (collectively, the "Services"). By registering for an account or using our Services, you agree to comply with and be bound by these Terms.</p>
+
+                <h3 className="text-lg font-bold">1. Acceptance of Terms</h3>
+                <p>By creating an account, checking the "Accept Terms" box, or otherwise accessing our Services, you represent that you have read, understood, and agree to these Terms. If you do not agree, you must not use our Services.</p>
+
+                <h3 className="text-lg font-bold">2. Legal Compliance and DPDP Act 2026</h3>
+                <p>ChatRaj is committed to complying with all applicable laws, including India's Digital Personal Data Protection (DPDP) Act 2026. Your use of the Services is subject to our Privacy Policy, which outlines how we collect, use, and protect your personal data in accordance with the DPDP Act 2026.</p>
+                <ul className="list-disc list-inside ml-4">
+                    <li><strong>Consent:</strong> We process your personal data only with your explicit consent, which you provide upon registration.</li>
+                    <li><strong>Purpose Limitation:</strong> Data is used solely for providing and improving the Services.</li>
+                    <li><strong>Data Fiduciary Obligations:</strong> We implement appropriate technical and organizational measures to ensure data security.</li>
+                </ul>
+
+                <h3 className="text-lg font-bold">3. Account Registration</h3>
+                <p>To use certain features, you must register for an account. You agree to provide accurate, current, and complete information and to keep this information updated. You are responsible for safeguarding your password and account details.</p>
+
+                <h3 className="text-lg font-bold">4. User Conduct</h3>
+                <p>You agree not to use the Services to:</p>
+                <ul className="list-disc list-inside ml-4">
+                    <li>Violate any local, state, national, or international law.</li>
+                    <li>Infringe upon the intellectual property rights of others.</li>
+                    <li>Upload or transmit viruses, malware, or any other malicious code.</li>
+                    <li>Engage in unauthorized scraping, data mining, or harvesting of personal data.</li>
+                </ul>
+
+                <h3 className="text-lg font-bold">5. Intellectual Property</h3>
+                <p>All content, features, and functionality on the ChatRaj platform, including but not limited to text, graphics, logos, and software, are the exclusive property of ChatRaj and are protected by copyright, trademark, and other intellectual property laws.</p>
+
+                <h3 className="text-lg font-bold">6. Termination</h3>
+                <p>We reserve the right to suspend or terminate your account at any time, with or without cause or notice, if we believe you have violated these Terms or for any other reason.</p>
+
+                <h3 className="text-lg font-bold">7. Disclaimer of Warranties</h3>
+                <p>The Services are provided "as is" and "as available" without any warranties of any kind, either express or implied. ChatRaj does not warrant that the Services will be uninterrupted, error-free, or secure.</p>
+
+                <h3 className="text-lg font-bold">8. Limitation of Liability</h3>
+                <p>In no event shall ChatRaj be liable for any indirect, incidental, special, consequential, or punitive damages arising out of or related to your use of the Services.</p>
+
+                <h3 className="text-lg font-bold">9. Changes to Terms</h3>
+                <p>We may update these Terms from time to time. We will notify you of any material changes by posting the new Terms on the platform. Your continued use of the Services after such modifications constitutes your acceptance of the revised Terms.</p>
+
+                <p className="mt-6">For any questions regarding these Terms, please contact us through the platform.</p>
+            </div>
+        </BaseModal>
+    );
+};
+
+export default TermsModal;

--- a/frontend/src/screens/Home.jsx
+++ b/frontend/src/screens/Home.jsx
@@ -12,6 +12,8 @@ import Blog from '../components/Blog.jsx';
 import ContactUs from '../components/ContactUs.jsx';
 import UiThemeModal from '../components/UiThemeModal.jsx';
 import { getThemeClasses } from '../utils/themeClasses.js';
+import TermsModal from '../components/TermsModal.jsx';
+import PrivacyModal from '../components/PrivacyModal.jsx';
 
 const AskChatRajModal = lazy(() => import('../components/AskChatRajModal.jsx'));
 
@@ -148,6 +150,8 @@ const Home = () => {
   const [showFabMenu, setShowFabMenu] = useState(false);
   const [showAskChatRajModal, setShowAskChatRajModal] = useState(false);
   const [showUiThemeModal, setShowUiThemeModal] = useState(false);
+  const [showTermsModal, setShowTermsModal] = useState(false);
+  const [showPrivacyModal, setShowPrivacyModal] = useState(false);
 
   const themeStyle = getThemeClasses(uiTheme, isDarkMode);
 
@@ -679,9 +683,13 @@ function greet(name) {
         </div>
       </div>
 
+      {/* Legal Modals */}
+      <TermsModal isOpen={showTermsModal} onRequestClose={() => setShowTermsModal(false)} />
+      <PrivacyModal isOpen={showPrivacyModal} onRequestClose={() => setShowPrivacyModal(false)} />
+
       {/* Footer */}
       <footer className={`relative z-10 px-8 py-6 mt-0 text-center border-t ${themeStyle.container}`}>
-        <p className={`${themeStyle.textMuted}`}>© 2025 ChatRaj All rights reserved.</p>
+        <p className={`${themeStyle.textMuted}`}>© 2026 ChatRaj All rights reserved. | <button type="button" onClick={() => setShowTermsModal(true)} className="hover:underline focus:outline-none">Terms of Service</button> | <button type="button" onClick={() => setShowPrivacyModal(true)} className="hover:underline focus:outline-none">Privacy Policy</button></p>
       </footer>
 
       <Suspense fallback={<div>Loading...</div>}>

--- a/frontend/src/screens/Register.jsx
+++ b/frontend/src/screens/Register.jsx
@@ -7,6 +7,8 @@ import { useToast } from '../context/toast.context';
 import { getThemeClasses } from '../utils/themeClasses.js';
 import axios from '../config/axios';
 import anime from 'animejs';
+import TermsModal from '../components/TermsModal.jsx';
+import PrivacyModal from '../components/PrivacyModal.jsx';
 
 const Register = () => {
     const [email, setEmail] = useState('');
@@ -18,6 +20,9 @@ const Register = () => {
     const [showOtpModal, setShowOtpModal] = useState(false);
     const [otp, setOtp] = useState('');
     const [userId, setUserId] = useState('');
+    const [acceptTerms, setAcceptTerms] = useState(false);
+    const [showTermsModal, setShowTermsModal] = useState(false);
+    const [showPrivacyModal, setShowPrivacyModal] = useState(false);
     const { setUser } = useContext(UserContext) || {};
     const { isDarkMode = false, uiTheme = "default" } = useContext(ThemeContext) || {};
     const { showToast } = useToast();
@@ -61,6 +66,10 @@ const Register = () => {
     function submitHandler(e) {
         e.preventDefault();
         setErrorMsg('');
+        if (!acceptTerms) {
+            setErrorMsg('You must accept the Terms of Service and Privacy Policy to register.');
+            return;
+        }
         if (password !== confirmPassword) {
             setErrorMsg('Passwords do not match.');
             return;
@@ -207,6 +216,10 @@ const Register = () => {
                 ))}
             </div>
 
+            {/* Legal Modals */}
+            <TermsModal isOpen={showTermsModal} onRequestClose={() => setShowTermsModal(false)} />
+            <PrivacyModal isOpen={showPrivacyModal} onRequestClose={() => setShowPrivacyModal(false)} />
+
             <div className={`form-container relative z-10 w-full max-w-md p-8 ${themeStyle.container}`}>
                 <button
                     type="button"
@@ -308,6 +321,26 @@ const Register = () => {
                                 placeholder="••••••••"
                                 required
                             />
+                        </div>
+                    </div>
+
+                    <div className="mb-6 flex items-start">
+                        <div className="flex items-center h-5">
+                            <input
+                                id="terms"
+                                type="checkbox"
+                                checked={acceptTerms}
+                                onChange={(e) => setAcceptTerms(e.target.checked)}
+                                className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2"
+                            />
+                        </div>
+                        <div className="ml-3 text-sm">
+                            <label htmlFor="terms" className={`font-medium ${themeStyle.textMain}`}>
+                                I accept the{' '}
+                                <button type="button" onClick={() => setShowTermsModal(true)} className="text-blue-500 hover:underline focus:outline-none">Terms of Service</button>
+                                {' '}and{' '}
+                                <button type="button" onClick={() => setShowPrivacyModal(true)} className="text-blue-500 hover:underline focus:outline-none">Privacy Policy</button>
+                            </label>
                         </div>
                     </div>
 


### PR DESCRIPTION
This PR introduces required legal compliance updates according to the DPDP Act 2026. Two new React components (`TermsModal.jsx` and `PrivacyModal.jsx`) have been generated and integrated across the frontend. Users are now required to check a mandatory 'Accept Terms' checkbox before registering an account. The application footer has also been updated to the correct year and linked to these new legal documents.

---
*PR created automatically by Jules for task [16739854352964028748](https://jules.google.com/task/16739854352964028748) started by @Abhirajgautam28*

## Summary by Sourcery

Add legal compliance UI for DPDP Act 2026 by introducing reusable Terms and Privacy modals and enforcing acceptance during registration.

New Features:
- Introduce reusable Terms of Service and Privacy Policy modal components with DPDP Act 2026-compliant copy.
- Require users to explicitly accept the Terms of Service and Privacy Policy via a checkbox before completing registration.
- Expose Terms of Service and Privacy Policy access from the home page footer via modal links.

Enhancements:
- Update the application footer year to 2026 to reflect current legal copy.