### PR TITLE
fix(security): address IP spoofing vulnerability in admin audit log

### DIFF
--- a/Backend/app.js
+++ b/Backend/app.js
@@ -29,6 +29,10 @@ const allowedOrigins = [
 
 const app = express();
 
+// Trust the first proxy (e.g. Vercel, Render) to allow Express to correctly
+// extract the client's real IP from X-Forwarded-For and detect HTTPS.
+app.set('trust proxy', 1);
+
 // CORS debug logger
 const corsErrorLogger = (err, req, res, next) => {
   if (err && err.message && err.message.includes('CORS')) {

--- a/Backend/controllers/user.controller.js
+++ b/Backend/controllers/user.controller.js
@@ -312,7 +312,7 @@ export const adminGetOtpController = async (req, res) => {
 
         // Audit access: log who requested this and what they requested.
         try {
-            const requesterIp = req.ip || req.headers['x-forwarded-for'] || req.connection && req.connection.remoteAddress;
+            const requesterIp = req.ip;
             const adminMasked = typeof adminKey === 'string' ? `***${adminKey.slice(-4)}` : '<none>';
             const audit = {
                 timestamp: new Date().toISOString(),

--- a/Backend/tests/security/ip_spoofing.test.js
+++ b/Backend/tests/security/ip_spoofing.test.js
@@ -1,0 +1,45 @@
+import request from 'supertest';
+import express from 'express';
+
+describe('IP Spoofing Protection', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    // Enable trust proxy as we did in Backend/app.js
+    app.set('trust proxy', 1);
+
+    app.get('/test-ip', (req, res) => {
+      res.json({ ip: req.ip, secure: req.secure });
+    });
+  });
+
+  test('should correctly identify client IP with trust proxy 1', async () => {
+    // With trust proxy 1, the rightmost IP in X-Forwarded-For is trusted as the
+    // downstream proxy, and the IP before it is considered the client's IP.
+    const response = await request(app)
+      .get('/test-ip')
+      .set('X-Forwarded-For', '203.0.113.1');
+
+    // In a local test with trust proxy 1, X-Forwarded-For: 'client'
+    // Express trusts the immediate peer (the test runner) and takes the
+    // rightmost entry in X-Forwarded-For as the client IP.
+    expect(response.body.ip).toBe('203.0.113.1');
+  });
+
+  test('should detect HTTPS via X-Forwarded-Proto when trust proxy is enabled', async () => {
+    const response = await request(app)
+      .get('/test-ip')
+      .set('X-Forwarded-Proto', 'https');
+
+    expect(response.body.secure).toBe(true);
+  });
+
+  test('should NOT detect HTTPS via X-Forwarded-Proto if it is not https', async () => {
+    const response = await request(app)
+      .get('/test-ip')
+      .set('X-Forwarded-Proto', 'http');
+
+    expect(response.body.secure).toBe(false);
+  });
+});

--- a/Backend/utils/security.js
+++ b/Backend/utils/security.js
@@ -48,7 +48,9 @@ export function isSecureFromRequest(req) {
   if (process.env.FORCE_SECURE_COOKIES === 'true' || process.env.NODE_ENV === 'production') return true;
   if (!req) return false;
   try {
-    return Boolean(req.secure || (req.headers && String(req.headers['x-forwarded-proto']) === 'https'));
+    // When 'trust proxy' is enabled in Express, req.secure correctly
+    // reflects the X-Forwarded-Proto header from the trusted proxy.
+    return Boolean(req.secure);
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
- Enable 'trust proxy' in Express app to correctly handle headers from reverse proxies.
- Update user controller to use req.ip for audit logging.
- Update security utils to use req.secure for protocol detection.
- Add security test for IP spoofing protection.

# Pull Request

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

Fixes #(issue)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [ ] My code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

_Please add screenshots to help explain your changes._

## Additional context

_Add any other context about the pull request here._

## Summary by Sourcery

Harden request handling and audit logging against IP spoofing by correctly trusting the proxy and relying on Express-derived connection metadata.

Bug Fixes:
- Prevent incorrect client IP and protocol detection behind reverse proxies that could enable IP spoofing in admin audit logs.

Enhancements:
- Configure the Express app to trust the first upstream proxy so that client IP and protocol are derived from trusted proxy headers.
- Simplify secure-request detection logic to rely on Express's req.secure flag when trust proxy is enabled.

Tests:
- Add a security test suite covering IP spoofing protection and request metadata handling behind proxies.