### PR TITLE
🔒 Fix Information Exposure Vulnerability in Error Handlers

### DIFF
--- a/Backend/app.js
+++ b/Backend/app.js
@@ -185,7 +185,7 @@ app.use((err, req, res, next) => {
     logger.error('CSRF validation failed:', err.message);
     return res.status(403).json({
       error: 'Invalid CSRF token',
-      message: process.env.NODE_ENV === 'development' ? err.message : 'Forbidden'
+      message: 'Forbidden'
     });
   }
 
@@ -193,7 +193,7 @@ app.use((err, req, res, next) => {
   if (!res.headersSent) {
     res.status(status).json({
       error: 'Something broke!',
-      message: process.env.NODE_ENV === 'development' ? err.message : 'Internal Server Error'
+      message: 'Internal Server Error'
     });
   }
 });


### PR DESCRIPTION
🎯 **What:** The global error handler and CSRF error handler conditionally leaked `err.message` to clients when `NODE_ENV === 'development'`.
⚠️ **Risk:** If `NODE_ENV` is ever misconfigured or accidentally set to `development` in a live environment, internal errors, stack traces, and database details could be exposed to end users and attackers.
🛡️ **Solution:** Removed the conditional `NODE_ENV` check and hardcoded safe, generic strings (`'Internal Server Error'` and `'Forbidden'`) to be unconditionally returned for these errors, ensuring secure-by-default behavior across all environments.

---
*PR created automatically by Jules for task [12781878355047304486](https://jules.google.com/task/12781878355047304486) started by @Abhirajgautam28*

## Summary by Sourcery

Harden error responses to avoid leaking internal error messages across environments.

Bug Fixes:
- Ensure CSRF error responses always return a generic 'Forbidden' message instead of conditionally exposing the underlying error in development.
- Ensure generic internal server error responses always return 'Internal Server Error' instead of conditionally exposing the underlying error message in development.