### PR TITLE
fix: secure /update-password endpoint with purpose-bound JWT

### DIFF
--- a/Backend/controllers/user.controller.js
+++ b/Backend/controllers/user.controller.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
 import { logger } from '../utils/logger.js';
 
 // Send OTP for password reset (used in Login.jsx)
@@ -11,8 +12,7 @@ export const sendOtpController = async (req, res) => {
         if (!user) return res.status(404).json({ message: 'User not found' });
         // Generate OTP
         const otp = generateOTP(7);
-        user.otp = otp;
-        user.isVerified = false;
+        user.resetPasswordOtp = otp;
         await user.save();
         await sendOtpEmail(user.email, otp);
         res.status(200).json({ message: 'OTP sent to email.' });
@@ -205,10 +205,17 @@ export const verifyOtpController = async (req, res) => {
             return res.status(400).json({ message: 'Invalid User ID' });
         }
         user = await userModel.findById(userId).select('+otp');
+        if (!user) return res.status(404).json({ message: 'User not found' });
+        if (user.otp !== otp) return res.status(401).json({ message: 'Invalid OTP' });
+        user.isVerified = true;
+        user.otp = undefined;
+        await user.save();
+        const token = await user.generateJWT();
+        return res.status(200).json({ message: 'Verified successfully', token, user });
     } else if (email) {
         const { value: normalizedEmail, isValid } = normalizeEmail(email);
         if (!isValid) return res.status(400).json({ message: 'Valid email is required' });
-        user = await userModel.findOne({ email: normalizedEmail }).select('+otp');
+        user = await userModel.findOne({ email: normalizedEmail }).select('+otp +resetPasswordOtp');
         // If user not found in DB, check for a pending registration stored in Redis
         // (we persist pending registrations there until the user verifies via OTP).
         if (!user) {
@@ -264,6 +271,29 @@ export const verifyOtpController = async (req, res) => {
                     return res.status(500).json({ message: 'Failed to create account' });
                 }
             }
+            return res.status(404).json({ message: 'User not found' });
+        } else {
+            // Password reset verification flow
+            if (user.resetPasswordOtp && user.resetPasswordOtp === otp) {
+                user.resetPasswordOtp = undefined;
+                await user.save();
+                // Issue a short-lived reset token
+                const resetToken = jwt.sign(
+                    { email: user.email, purpose: 'password-reset' },
+                    process.env.JWT_SECRET,
+                    { expiresIn: '15m' }
+                );
+                return res.status(200).json({ message: 'OTP verified', resetToken });
+            }
+            // Registration verification fallback logic for email (legacy approach)
+            if (user.otp === otp) {
+                 user.isVerified = true;
+                 user.otp = undefined;
+                 await user.save();
+                 const token = await user.generateJWT();
+                 return res.status(200).json({ message: 'Verified successfully', token, user });
+            }
+            return res.status(401).json({ message: 'Invalid OTP' });
         }
     }
 };
@@ -382,20 +412,11 @@ export const getAllUsersController = async (req, res) => {
     }
 }
 
-export const resetPasswordController = async (req, res) => {
-    try {
-        const { email } = req.body;
-        const result = await userService.resetPassword(email);
-        return response.success(res, result);
-    } catch (err) {
-        logger.error('resetPasswordController error:', err);
-        res.status(500).json({ message: 'Internal server error' });
-    }
-};
-
 export const updatePasswordController = async (req, res) => {
     try {
-        const { email, newPassword } = req.body;
+        const { newPassword } = req.body;
+        // The email is extracted from the JWT token via the authResetPassword middleware
+        const email = req.resetUser.email;
         const result = await userService.updatePassword(email, newPassword);
         return response.success(res, result);
     } catch (err) {

--- a/Backend/middleware/auth.middleware.js
+++ b/Backend/middleware/auth.middleware.js
@@ -25,3 +25,25 @@ export const authUser = async (req, res, next) => {
         res.status(401).json({ error: 'Unauthorized User' });
     }
 }
+
+export const authResetPassword = async (req, res, next) => {
+    try {
+        const authHeader = req.headers.authorization;
+        const token = authHeader && authHeader.split(' ')[1];
+
+        if (!token) {
+            return res.status(401).json({ error: 'Unauthorized User' });
+        }
+
+        const decoded = jwt.verify(token, process.env.JWT_SECRET);
+        if (decoded.purpose !== 'password-reset') {
+            return res.status(401).json({ error: 'Invalid token purpose' });
+        }
+
+        req.resetUser = decoded;
+        next();
+    } catch (error) {
+        logger.error("Auth reset password middleware error:", error);
+        res.status(401).json({ error: 'Unauthorized User' });
+    }
+}

--- a/Backend/models/user.model.js
+++ b/Backend/models/user.model.js
@@ -35,6 +35,10 @@ const userSchema = new mongoose.Schema({
         select: false,
         required: true
     },
+    resetPasswordOtp: {
+        type: String,
+        select: false
+    },
     otp: {
         type: String,
         select: false

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -31,7 +31,7 @@
         "validator": "^13.15.23"
       },
       "devDependencies": {
-        "@babel/preset-env": "^7.29.2",
+        "@babel/preset-env": "^7.29.3",
         "babel-jest": "^30.3.0",
         "jest": "^30.2.0",
         "rimraf": "^6.1.3",
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -416,6 +416,23 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.3.tgz",
+      "integrity": "sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1521,19 +1538,20 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
-      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.3.tgz",
+      "integrity": "sha512-ySZypNLAIH1ClygLDQzVMoGQRViATnkHkYYV6TcNDz+8+jwZCdsguGvsb3EY5d9wyWyhmF1iSuFM0Yh5XPnqSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.0",
+        "@babel/compat-data": "^7.29.3",
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.3",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
         "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -45,7 +45,7 @@
     "validator": "^13.15.23"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.29.2",
+    "@babel/preset-env": "^7.29.3",
     "babel-jest": "^30.3.0",
     "jest": "^30.2.0",
     "rimraf": "^6.1.3",

--- a/Backend/routes/user.routes.js
+++ b/Backend/routes/user.routes.js
@@ -53,8 +53,7 @@ router.post('/login',
   userController.loginController
 );
 
-router.post('/reset-password', sensitiveLimiter, userController.resetPasswordController);
-router.post('/update-password', sensitiveLimiter, userController.updatePasswordController);
+router.post('/update-password', sensitiveLimiter, authMiddleware.authResetPassword, userController.updatePasswordController);
 
 router.get('/profile', authLimiter, authMiddleware.authUser, userController.profileController);
 

--- a/Backend/services/user.service.js
+++ b/Backend/services/user.service.js
@@ -26,8 +26,7 @@ export const sendOtp = async (email) => {
     if (!user) throw new Error('User not found');
 
     const otp = generateOTP(7);
-    user.otp = otp;
-    user.isVerified = false;
+    user.resetPasswordOtp = otp;
     await user.save();
 
     await sendOtpEmail(user.email, otp);
@@ -63,7 +62,7 @@ export const verifyOtp = async ({ userId, email, otp }) => {
     } else if (email) {
         const { value: normalizedEmail, isValid } = normalizeEmail(email);
         if (!isValid) throw new Error('Valid email is required');
-        user = await userModel.findOne({ email: normalizedEmail }).select('+otp');
+        user = await userModel.findOne({ email: normalizedEmail }).select('+otp +resetPasswordOtp');
 
         if (!user) {
             const pendingKey = `pending:registration:${normalizedEmail}`;
@@ -92,6 +91,18 @@ export const verifyOtp = async ({ userId, email, otp }) => {
     }
 
     if (!user) throw new Error('User not found');
+
+    if (user.resetPasswordOtp && user.resetPasswordOtp === otp) {
+        user.resetPasswordOtp = undefined;
+        await user.save();
+        const resetToken = jwt.sign(
+            { email: user.email, purpose: 'password-reset' },
+            process.env.JWT_SECRET,
+            { expiresIn: '15m' }
+        );
+        return { message: 'OTP verified', resetToken };
+    }
+
     if (user.otp !== otp) throw new Error('Invalid OTP');
 
     user.isVerified = true;
@@ -150,20 +161,6 @@ export const loginUser = async (email, password) => {
 
 export const getAllUsers = async ({ userId }) => {
     return await userModel.find({ _id: { $ne: userId } });
-};
-
-export const resetPassword = async (email) => {
-    const { value: normalizedEmail, isValid } = normalizeEmail(email);
-    if (!isValid) throw new Error('Valid email is required');
-    const user = await userModel.findOne({ email: normalizedEmail });
-    if (!user) throw new Error('User not found');
-
-    const resetToken = jwt.sign(
-        { email: user.email },
-        process.env.JWT_SECRET,
-        { expiresIn: '15m' }
-    );
-    return { message: 'Reset link sent to email', resetToken };
 };
 
 export const updatePassword = async (email, newPassword) => {

--- a/frontend/src/screens/Login.jsx
+++ b/frontend/src/screens/Login.jsx
@@ -27,6 +27,7 @@ const Login = () => {
     const otpTimerRef = useRef(null);
     const [resetOtp, setResetOtp] = useState('');
     const [resetOtpVerified, setResetOtpVerified] = useState(false);
+    const [resetToken, setResetToken] = useState('');
     const [resetNewPassword, setResetNewPassword] = useState('');
     const [resetConfirmPassword, setResetConfirmPassword] = useState('');
     const [resetSuccess, setResetSuccess] = useState(false);
@@ -167,7 +168,8 @@ const Login = () => {
             return;
         }
         try {
-            await axios.post('/api/users/verify-otp', { email: resetEmail, otp: resetOtp });
+            const res = await axios.post('/api/users/verify-otp', { email: resetEmail, otp: resetOtp });
+            setResetToken(res.data.resetToken);
             setResetOtpVerified(true);
         } catch {
             setResetError('Invalid OTP. Please check your email and try again.');
@@ -191,8 +193,11 @@ const Login = () => {
         setResetInProgress(true);
         try {
             await axios.post('/api/users/update-password', {
-                email: resetEmail,
                 newPassword: resetNewPassword
+            }, {
+                headers: {
+                    Authorization: `Bearer ${resetToken}`
+                }
             });
             setResetSuccess(true);
             setTimeout(() => {
@@ -202,6 +207,7 @@ const Login = () => {
                 setResetOtp('');
                 setResetOtpSent(false);
                 setResetOtpVerified(false);
+                setResetToken('');
                 setResetNewPassword('');
                 setResetConfirmPassword('');
                 setShowPassword(false);


### PR DESCRIPTION
The /update-password endpoint was previously unauthenticated, allowing any user's password to be changed if their email was known. This commit implements a secure OTP-to-JWT flow:
- Adds a `resetPasswordOtp` field to the User model to prevent account lockouts during password reset requests.
- Updates the OTP verification service to issue a short-lived JWT `{ purpose: 'password-reset' }` upon successful OTP validation.
- Introduces `authResetPassword` middleware to enforce this token on the `/update-password` route.
- Updates the frontend to handle and send the new token.
- Removes legacy unused `/reset-password` endpoints.

# Pull Request

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

Fixes #(issue)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [ ] My code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

_Please add screenshots to help explain your changes._

## Additional context

_Add any other context about the pull request here._

## Summary by Sourcery

Secure the password reset flow by requiring a purpose-bound JWT for updating passwords and aligning backend and frontend logic with the new flow.

Bug Fixes:
- Prevent unauthorized password changes by removing the unauthenticated /reset-password flow and enforcing a verified token on /update-password.

Enhancements:
- Introduce a resetPasswordOtp field and flow to separate password reset OTPs from registration verification and avoid unintended account verification changes.
- Add authResetPassword middleware to validate short-lived password-reset JWTs before allowing password updates.
- Simplify OTP verification logic to issue standard auth JWTs for registration while returning dedicated reset tokens for password resets.
- Update frontend login/reset password screen to store the password-reset token after OTP verification and send it as a Bearer token when updating the password.

Build:
- Bump @babel/preset-env dev dependency patch version in the backend package.