### PR TITLE
fix: resolve PageTracker ReferenceError in AppRoutes

### DIFF
--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -5,6 +5,11 @@ import { ChatRajThemeProvider } from '../context/chatraj-theme.context';
 import LoadingScreen from '../components/LoadingScreen';
 import usePageTracking from '../hooks/usePageTracking';
 
+const PageTracker = () => {
+    usePageTracking();
+    return null;
+};
+
 const Login = lazy(() => import('../screens/Login'));
 const Register = lazy(() => import('../screens/Register'));
 const Home = lazy(() => import('../screens/Home'));


### PR DESCRIPTION
This submission resolves the bug where users were encountering a blank page on the production site due to a ReferenceError (`PageTracker is not defined`).

`AppRoutes.jsx` was importing the `usePageTracking` hook but trying to render `<PageTracker />` without defining it. I defined the `PageTracker` functional component to properly execute the `usePageTracking` hook and return `null`, allowing page tracking to function properly within the `<BrowserRouter>` without breaking the site structure.

---
*PR created automatically by Jules for task [9461204963047196389](https://jules.google.com/task/9461204963047196389) started by @Abhirajgautam28*

## Summary by Sourcery

Bug Fixes:
- Resolve production blank-page issue caused by an undefined PageTracker reference in AppRoutes by introducing a dedicated PageTracker component.