### PR TITLE
🔒 fix: restrict overly permissive Vercel CORS regex

### DIFF
--- a/Backend/app.js
+++ b/Backend/app.js
@@ -49,12 +49,12 @@ const corsErrorLogger = (err, req, res, next) => {
 
 // Improved CORS middleware for Vercel/Render/localhost
 const dynamicCors = (origin, callback) => {
-  const vercelRegex = /^https:\/\/[a-zA-Z0-9-]+\.vercel\.app$/;
+  // Restrict Vercel origins to only preview deployments for the specific chatraj project
+  const vercelRegex = /^https:\/\/chatraj(-[a-zA-Z0-9-]+)?-abhiraj-gautams-projects\.vercel\.app$/;
   if (!origin) return callback(null, true);
   if (
     allowedOrigins.includes(origin) ||
-    vercelRegex.test(origin) ||
-    origin === 'null'
+    vercelRegex.test(origin)
   ) {
     return callback(null, true);
   }

--- a/Backend/tests/cors_unit.test.js
+++ b/Backend/tests/cors_unit.test.js
@@ -1,0 +1,53 @@
+import { jest } from '@jest/globals';
+
+const allowedOrigins = [
+  'https://chatraj-frontend.vercel.app',
+  'https://chatraj.vercel.app',
+  'http://localhost:5173',
+  'http://localhost:5174',
+  'https://chatraj-fpo1pa3bz-abhiraj-gautams-projects.vercel.app'
+];
+
+const dynamicCors = (origin, callback) => {
+  const vercelRegex = /^https:\/\/chatraj(-[a-zA-Z0-9-]+)?-abhiraj-gautams-projects\.vercel\.app$/;
+  if (!origin) return callback(null, true);
+  if (
+    allowedOrigins.includes(origin) ||
+    vercelRegex.test(origin)
+  ) {
+    return callback(null, true);
+  }
+  return callback(new Error('Not allowed by CORS'));
+};
+
+describe('CORS validation regex', () => {
+  const checkOrigin = (origin) => {
+    return new Promise((resolve, reject) => {
+      dynamicCors(origin, (err, success) => {
+        if (err) return reject(err);
+        resolve(success);
+      });
+    });
+  };
+
+  it('should allow explicitly allowed origin', async () => {
+    await expect(checkOrigin('https://chatraj.vercel.app')).resolves.toBe(true);
+  });
+
+  it('should allow legitimate vercel preview URL', async () => {
+    const previewUrl = 'https://chatraj-frontend-1234abc-abhiraj-gautams-projects.vercel.app';
+    await expect(checkOrigin(previewUrl)).resolves.toBe(true);
+  });
+
+  it('should block arbitrary vercel domain', async () => {
+    await expect(checkOrigin('https://attacker-project.vercel.app')).rejects.toThrow('Not allowed by CORS');
+  });
+
+  it('should block similar but malicious domains', async () => {
+    await expect(checkOrigin('https://chatraj-malicious-abhiraj-gautams-projects.vercel.app.attacker.com')).rejects.toThrow('Not allowed by CORS');
+  });
+
+  it('should block null origin (e.g. from sandboxed iframes or local files)', async () => {
+    await expect(checkOrigin('null')).rejects.toThrow('Not allowed by CORS');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `dynamicCors` middleware in `Backend/app.js` contained a very permissive regular expression for Vercel origins (`/^https:\/\/[a-zA-Z0-9-]+\.vercel\.app$/`). It also permitted a `null` origin.

⚠️ **Risk:** The previous regex allowed *any* `*.vercel.app` domain. Because anyone can register a free subdomain on Vercel, an attacker could host a malicious application on Vercel to fully bypass CORS restrictions and perform Cross-Origin attacks against the backend API. Additionally, allowing `null` origins is dangerous because an attacker could use a sandboxed `<iframe>` or a local `.html` file, both of which send a `null` origin, to bypass CORS rules.

🛡️ **Solution:** 
1. Tightened the `vercelRegex` to exclusively match preview branch deployments tied directly to this project's Vercel namespace (`^https:\/\/chatraj(-[a-zA-Z0-9-]+)?-abhiraj-gautams-projects\.vercel\.app$`).
2. Removed the `origin === 'null'` allowance entirely.
3. Added `cors_unit.test.js` to systematically verify that explicitly allowed origins pass, valid Vercel preview URLs pass, and malicious Vercel subdomains (along with `null` origins) are successfully blocked.

---
*PR created automatically by Jules for task [7804986410220412482](https://jules.google.com/task/7804986410220412482) started by @Abhirajgautam28*

## Summary by Sourcery

Tighten backend CORS origin validation for Vercel deployments and add tests to prevent abuse via arbitrary Vercel or null origins.

Bug Fixes:
- Restrict Vercel origin matching to this project’s preview deployments to prevent arbitrary *.vercel.app domains from bypassing CORS.
- Remove support for 'null' origins so sandboxed iframes or local files can no longer circumvent CORS rules.

Tests:
- Add unit tests for the dynamic CORS middleware to cover allowed origins, valid project-specific Vercel preview URLs, and rejection of malicious or null origins.