### PR TITLE
🔒 Secure debugGetRawOtpController development endpoint

### DIFF
--- a/Backend/controllers/user.controller.js
+++ b/Backend/controllers/user.controller.js
@@ -443,6 +443,11 @@ export const adminGetOtpController = async (req, res) => {
 export const debugGetRawOtpController = async (req, res) => {
     try {
         if (process.env.NODE_ENV === 'production') return res.status(403).json({ message: 'Disabled in production' });
+
+        const adminKey = req.get('x-admin-key');
+        if (!process.env.ADMIN_API_KEY) return res.status(403).json({ message: 'Admin API key not configured on server' });
+        if (!adminKey || adminKey !== process.env.ADMIN_API_KEY) return res.status(403).json({ message: 'Forbidden' });
+
         const { email, userId } = req.query;
         if (!email && !userId) return res.status(400).json({ message: 'Provide email or userId' });
 

--- a/frontend/playwright/tests/e2e-coverage.spec.js
+++ b/frontend/playwright/tests/e2e-coverage.spec.js
@@ -56,9 +56,14 @@ test.describe('ChatRaj Full Application E2E Test Suite - Continuous Flow', () =>
 
     // Try to fetch the OTP from the backend debug endpoint (dev-only).
     let otpValue = null;
+    const adminKey = process.env.ADMIN_API_KEY || 'default_admin_key';
     for (let attempt = 0; attempt < 30; attempt++) {
       try {
-        const resp = await pageA.request.get(`${BACKEND_URL}/api/users/debug/raw-otp?email=${encodeURIComponent(NEW_USER_EMAIL)}`);
+        const resp = await pageA.request.get(`${BACKEND_URL}/api/users/debug/raw-otp?email=${encodeURIComponent(NEW_USER_EMAIL)}`, {
+          headers: {
+            'x-admin-key': adminKey
+          }
+        });
         if (resp && resp.status && resp.status() === 200) {
           const json = await resp.json();
           if (json && json.otp) {


### PR DESCRIPTION
🎯 **What:** Secured the `debugGetRawOtpController` endpoint by adding an `x-admin-key` header requirement, protecting it against unauthorized access, while ensuring Playwright E2E tests pass the correct headers to remain functional.
⚠️ **Risk:** The previous endpoint, while disabled in production, lacked strong authentication. In lower environments or misconfigured deployments, this could allow unauthenticated retrieval of raw user OTPs, bypassing the MFA/registration protections for any account.
🛡️ **Solution:** Added a check requiring `req.get('x-admin-key') === process.env.ADMIN_API_KEY`, blocking access if the key is missing from the server or the request. Retained the existing environment check for defense-in-depth. Modified `e2e-coverage.spec.js` to send `process.env.ADMIN_API_KEY || 'default_admin_key'` when polling for the OTP.

---
*PR created automatically by Jules for task [14279115808309952418](https://jules.google.com/task/14279115808309952418) started by @Abhirajgautam28*

## Summary by Sourcery

Secure the debug raw OTP development endpoint with an admin API key check and update Playwright E2E tests to send the required header.

New Features:
- Introduce x-admin-key header authentication for the debugGetRawOtpController development-only OTP endpoint.

Enhancements:
- Return explicit 403 errors when the admin API key is missing on the server or does not match the request header in the debug OTP endpoint.

Tests:
- Adjust Playwright e2e-coverage test to include the admin API key header when polling the debug raw OTP endpoint.