### PR TITLE
Fix 500 internal server error during login and page loads

### DIFF
--- a/Backend/app.js
+++ b/Backend/app.js
@@ -80,7 +80,7 @@ app.use(cors({
 app.use(corsErrorLogger);
 
 app.use(helmet({ crossOriginResourcePolicy: false }));
-app.use(mongoSanitize());
+
 
 app.use(morgan('dev'));
 app.use(express.json());


### PR DESCRIPTION
Fixes the 500 internal server error preventing users from logging in on `chatraj-backend.onrender.com`.

The issue was caused by a duplicate invocation of the `express-mongo-sanitize` middleware (`app.use(mongoSanitize());`). In environments behind proxies (like Render), request objects can have getter-only properties, causing the default `mongoSanitize()` to crash with a `TypeError` when it tries to mutate them. 

The codebase already contained a safer custom implementation of `mongoSanitize` below it that applies the sanitizer safely per request without attempting reassignment. Removing the default middleware unblocks the backend and restores normal operation to all endpoints (e.g. `/csrf-token`, `/api/projects/showcase`).

---
*PR created automatically by Jules for task [3316288148306891528](https://jules.google.com/task/3316288148306891528) started by @Abhirajgautam28*

## Summary by Sourcery

Bug Fixes:
- Resolve 500 internal server errors by relying on the safer per-request mongo sanitization implementation instead of the crashing global middleware.